### PR TITLE
Ensure that parallels in ForkScanner follow the same reverse-order iteration rule

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
@@ -50,10 +50,11 @@ import java.util.Set;
  * Scanner that will scan down all forks when we hit parallel blocks before continuing, but generally runs in linear order
  * <p>Think of it as the opposite of {@link DepthFirstScanner}.
  *
- * <p>This is a fairly efficient way to visit all FlowNodes, and provides three useful guarantees:
+ * <p>This is a fairly efficient way to visit all FlowNodes, and provides four useful guarantees:
  * <ul>
- *   <li>Every FlowNode is visited, and visited EXACTLY ONCE (not true for LinearScanner)</li>
+ *   <li>Every FlowNode is visited, and visited EXACTLY ONCE (not true for LinearScanner, which misses some)</li>
  *   <li>All parallel branches are visited before we move past the parallel block (not true for DepthFirstScanner)</li>
+ *   <li>For parallels, we visit branches in reverse order (in fitting with end to start general flow)</li>
  *   <li>For EVERY block, the BlockEndNode is visited before the BlockStartNode (not true for DepthFirstScanner, with parallels)</li>
  * </ul>
  *
@@ -436,7 +437,7 @@ public class ForkScanner extends AbstractFlowScanner {
         ArrayDeque<FlowNode> branches = new ArrayDeque<FlowNode>();
         for (FlowNode f : parents) {
             if (!blackList.contains(f)) {
-                branches.add(f);
+                branches.addFirst(f);
             }
         }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScannerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScannerTest.java
@@ -364,13 +364,19 @@ public class FlowScannerTest {
         // We're going to test the ForkScanner in more depth since this is its natural use
         scanner = new ForkScanner();
         scanner.setup(heads);
-        assertNodeOrder("ForkedScanner", scanner, 15, 14, 13, 9, 8, 6, 12, 11, 10, 7, 4, 3, 2);
+        assertNodeOrder("ForkedScanner", scanner, 15, 14, 13,
+                    12, 11, 10, 7,// One parallel
+                    9, 8, 6, // other parallel
+                4, 3, 2); // end bit
         scanner.setup(heads, Collections.singleton(exec.getNode("9")));
         assertNodeOrder("ForkedScanner", scanner, 15, 14, 13, 12, 11, 10, 7, 4, 3, 2);
 
         // Test forkscanner midflow
         scanner.setup(exec.getNode("14"));
-        assertNodeOrder("ForkedScanner", scanner, 14, 13, 9, 8, 6, 12, 11, 10, 7, 4, 3, 2);
+        assertNodeOrder("ForkedScanner", scanner, 14, 13,
+                    12, 11, 10, 7, // Last parallel
+                    9, 8, 6, // First parallel
+                4, 3, 2); // end bit
 
         // Test forkscanner inside a parallel
 


### PR DESCRIPTION
Per [JENKINS-38309](https://issues.jenkins-ci.org/browse/JENKINS-38309) -- a little assistance to simplify things for Blue Ocean & company. 

@vivek  and @reviewbybees 