### PR TITLE
Make DepthFirstScanner obey first-last parallel branch ordering [JENKINS-38458]

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/DepthFirstScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/DepthFirstScanner.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.graphanalysis;
 
+import com.google.common.collect.Lists;
 import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
@@ -31,6 +32,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -38,9 +40,11 @@ import java.util.List;
 /** Does a simple and somewhat efficient depth-first search of all FlowNodes in the DAG.
  *
  *  <p>Iteration order: depth-first search, revisiting parallel branches once done.
- *  With parallel branches, the first branch is explored, then remaining branches are explored in reverse order.
  *
  * <p> The behavior is analogous to {@link org.jenkinsci.plugins.workflow.graph.FlowGraphWalker} but faster.
+ *  With parallel branches, the last branch is explored, then remaining branches are explored in reverse order.
+ *  This keeps ordering compatibility with FlowGraphWalker.
+ *
  *  @author Sam Van Oort
  */
 @NotThreadSafe
@@ -80,7 +84,7 @@ public class DepthFirstScanner extends AbstractFlowScanner {
 
         // Walk through parents of current node
         List<FlowNode> parents = current.getParents();  // Can't be null
-        for (FlowNode f : parents) {
+        for (FlowNode f : Lists.reverse(parents)) {
             // Only ParallelStep nodes may be visited multiple times... but we can't just filter those
             // because that's in workflow-cps plugin which depends on this one.
             if (!blackList.contains(f) && !(f instanceof BlockStartNode && visited.contains(f))) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/DepthFirstScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/DepthFirstScanner.java
@@ -24,26 +24,33 @@
 
 package org.jenkinsci.plugins.workflow.graphanalysis;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
+import java.lang.reflect.Array;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 
 /** Does a simple and somewhat efficient depth-first search of all FlowNodes in the DAG.
  *
  *  <p>Iteration order: depth-first search, revisiting parallel branches once done.
  *
  * <p> The behavior is analogous to {@link org.jenkinsci.plugins.workflow.graph.FlowGraphWalker} but faster.
- *  With parallel branches, the last branch is explored, then remaining branches are explored in reverse order.
- *  This keeps ordering compatibility with FlowGraphWalker.
+ *  With parallel branches, the first branch is explored, then remaining branches are explored in order.
+ *  This keeps ordering compatibility with {@link org.jenkinsci.plugins.workflow.graph.FlowGraphWalker} - it can be a drop-in replacement.
  *
  *  @author Sam Van Oort
  */
@@ -67,30 +74,41 @@ public class DepthFirstScanner extends AbstractFlowScanner {
 
     @Override
     protected void setHeads(@Nonnull Collection<FlowNode> heads) {
-        Iterator<FlowNode> it = heads.iterator();
-        if (it.hasNext()) {
-            FlowNode f = it.next();
-            myCurrent = f;
-            myNext = f;
+        if (heads.isEmpty()) {
+            return;
         }
-        while (it.hasNext()) {
-            queue.add(it.next());
+        ArrayList<FlowNode>  nodes = new ArrayList<FlowNode>(heads);
+        for(int i=nodes.size()-1; i >= 0; i--) {
+            queue.push(nodes.get(i));
         }
+        myCurrent = queue.pop();
+        myNext = myCurrent;
+    }
+
+    // Can be overridden with a more specific test
+    protected boolean possibleParallelStart(FlowNode f) {
+        return f instanceof BlockStartNode;
+    }
+
+    protected boolean testCandidate(FlowNode f, Collection<FlowNode> blackList) {
+        return !blackList.contains(f) && !((possibleParallelStart(f)) && visited.contains(f));
     }
 
     @Override
-    protected FlowNode next(@Nonnull FlowNode current, @Nonnull Collection<FlowNode> blackList) {
+    protected FlowNode next(@Nonnull FlowNode current, @Nonnull final Collection<FlowNode> blackList) {
         FlowNode output = null;
 
         // Walk through parents of current node
         List<FlowNode> parents = current.getParents();  // Can't be null
-        for (FlowNode f : Lists.reverse(parents)) {
-            // Only ParallelStep nodes may be visited multiple times... but we can't just filter those
-            // because that's in workflow-cps plugin which depends on this one.
-            if (!blackList.contains(f) && !(f instanceof BlockStartNode && visited.contains(f))) {
-                if (output == null ) {
-                    output = f;  // Do direct assignment rather than needless push/pop
-                } else {
+        if (parents.size() == 1) {  // Common case, make it more efficient
+            FlowNode f = parents.get(0);
+            if (testCandidate(f, blackList)) {
+                output = f;
+            }
+        } else if (parents.size() > 1) { // Add the branches in reverse order
+            for(int i=parents.size()-1; i>=0; i--) {
+                FlowNode f = parents.get(i);
+                if (testCandidate(f, blackList)) {
                     queue.push(f);
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/package-info.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/package-info.java
@@ -6,6 +6,13 @@
  * visiting all nodes via internal iteration.
  *
  * <p> Static methods and a few implementations are also provided in {@link org.jenkinsci.plugins.workflow.graphanalysis.FlowScanningUtils}.
+ * <p><em>How To Pick A FlowScanner For Iteration</em></p>
+ * <ol>
+ *     <li><em>Want fast iteration, don't care about visiting every node or parallels?</em> {@link org.jenkinsci.plugins.workflow.graphanalysis.LinearScanner}</li>
+ *     <li><em>Visit every node as fast as possible?</em> {@link org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner}</li>
+ *     <li><em>Visit every block in a predictable order, from end to start?</em> {@link org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner}</li>
+ *     <li><em>Fastest way to find preceding sibling or enclosing nodes?</em> {@link org.jenkinsci.plugins.workflow.graphanalysis.LinearBlockHoppingScanner}</li>
+ * </ol>
  */
 
 package org.jenkinsci.plugins.workflow.graphanalysis;


### PR DESCRIPTION
Per [JENKINS-38458](https://issues.jenkins-ci.org/browse/JENKINS-38458) and it will also incidentally solve [JENKINS-38457](https://issues.jenkins-ci.org/browse/JENKINS-38457).

As of this change, it's tested as a drop-in replacement for FlowGraphWalker with API compatibility. 