### PR TITLE
[JENKINS-38640] Use a GREEDY RemoteInputStream

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/StashManager.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/StashManager.java
@@ -119,13 +119,8 @@ public class StashManager {
         if (!storage.isFile()) {
             throw new AbortException("No such saved stash ‘" + name + "’");
         }
-        InputStream is = new FileInputStream(storage);
-        try {
-            workspace.untarFrom(is, FilePath.TarCompression.GZIP);
-            // currently nothing to print; listener is a placeholder
-        } finally {
-            is.close();
-        }
+        new FilePath(storage).untar(workspace, FilePath.TarCompression.GZIP);
+        // currently nothing to print; listener is a placeholder
     }
 
     /**


### PR DESCRIPTION
See [JENKINS-38640] (https://issues.jenkins-ci.org/browse/JENKINS-38640)

Changed from `untarFrom` to `untar` as the former [does not use](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/FilePath.java#L721) a GREEDY stream (maybe that should be changed in core), which should provide better performance.

Tested using [this tests](https://github.com/jenkinsci/workflow-basic-steps-plugin/blob/master/src/test/java/org/jenkinsci/plugins/workflow/support/steps/stash/StashTest.java)

@reviewbybees esp. @jglick 