### PR TITLE
Ensure that for SimpleBlockVisitor we find the REAL last branch for a parallel [JENKINS-38536]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,5 +88,12 @@
             <version>1.15</version>
             <scope>test</scope>
         </dependency>
+        <dependency>  <!-- For Semaphore step -->
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>2.1</version>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
@@ -329,7 +329,7 @@ public class ForkScanner extends AbstractFlowScanner {
 
         // Walk through, merging flownodes one-by-one until everything has merged to one ancestor
         boolean mergedAll = false;
-		// Ends when we merged all branches together, or hit the start of the flow without it
+        // Ends when we merged all branches together, or hit the start of the flow without it
         while (!mergedAll && iterators.size() > 0) {
             ListIterator<Filterator<FlowNode>> itIterator = iterators.listIterator();
             ListIterator<FlowPiece> pieceIterator = livePieces.listIterator();

--- a/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScannerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScannerTest.java
@@ -408,25 +408,25 @@ public class ForkScannerTest {
     }
 
     @Test
+    @Issue("JENKINS-38089")
     public void testVariousParallelCombos() throws Exception {
         WorkflowJob job = r.jenkins.createProject(WorkflowJob.class, "ParallelTimingBug");
         job.setDefinition(new CpsFlowDefinition(
-                "stage 'test' \n" +
-                        "    parallel([\n" +  // ID 5 is start
-                        "        'unit': {\n" +
-                        "          retry(1) {\n" +
-                        "            sleep 1;\n" +
-                        "            sleep 10; echo 'hello'; \n" +
-                        "          }\n" +
-                        "        },\n" +
-                        "        'otherunit': {\n" +
-                        "            retry(1) {\n" +
-                        "              sleep 1;\n" +
-                        "              sleep 5; \n" +
-                        "              echo 'goodbye'   \n" +
-                        "            }\n" +
-                        "        }\n" +  // end of branch:
-                        "    ])\n"
+            // Seemingly gratuitous sleep steps are because original issue required specific timing to reproduce
+            // TODO test to see if we still need them to reproduce JENKINS-38089
+            "stage 'test' \n" +
+            "    parallel 'unit': {\n" +
+            "          retry(1) {\n" +
+            "            sleep 1;\n" +
+            "            sleep 10; echo 'hello'; \n" +
+            "          }\n" +
+            "        }, 'otherunit': {\n" +
+            "            retry(1) {\n" +
+            "              sleep 1;\n" +
+            "              sleep 5; \n" +
+            "              echo 'goodbye'   \n" +
+            "            }\n" +
+            "        }"
         ));
         /*Node dump follows, format:
         [ID]{parent,ids}(millisSinceStartOfRun) flowNodeClassName stepDisplayName [st=startId if a block end node]

--- a/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScannerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScannerTest.java
@@ -44,6 +44,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.junit.Assert;
 
@@ -563,8 +564,10 @@ public class ForkScannerTest {
         r.waitForCompletion(run);
     }
 
+    @Issue("JENKINS-38536")
     @Test
     public void testParallelCorrectEndNodeForVisitor() throws Exception {
+        // Verify that SimpleBlockVisitor actually gets the *real* last node not just the last declared branch
         WorkflowJob jobPauseFirst = r.jenkins.createProject(WorkflowJob.class, "PauseFirst");
         jobPauseFirst.setDefinition(new CpsFlowDefinition("" +
                 "stage 'primero'\n" +
@@ -580,7 +583,7 @@ public class ForkScannerTest {
                 ));
 
         WorkflowJob jobPauseMiddle = r.jenkins.createProject(WorkflowJob.class, "PauseMiddle");
-        jobPauseSecond.setDefinition(new CpsFlowDefinition("" +
+        jobPauseMiddle.setDefinition(new CpsFlowDefinition("" +
                 "stage 'primero'\n" +
                 "parallel 'success' : {echo 'succeed'}, \n" +
                 " 'pause':{ sleep 1; semaphore 'wait3'; }, \n" +


### PR DESCRIPTION
... not just the last one declared on that parallel block.

Solves [JENKINS-38536](https://issues.jenkins-ci.org/browse/JENKINS-38536).

@reviewbybees especially @jglick

- [x] Integrate nits from https://github.com/jenkinsci/workflow-api-plugin/pull/25