### PR TITLE
Create & use optimized getAction API for FlowNodes that only uses nontransient actions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-api</artifactId>
-    <version>2.5-optimized2-SNAPSHOT</version>
+    <version>2.5-optimized3-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: API</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+API+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-api</artifactId>
-    <version>2.5-SNAPSHOT</version>
+    <version>2.5-optimized-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: API</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+API+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-api</artifactId>
+    <!-- Yes, this is temporary for benchmarking etc, will be reverted before merge -->
     <version>2.5-optimized3-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: API</name>

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-api</artifactId>
-    <!-- Yes, this is temporary for benchmarking etc, will be reverted before merge -->
-    <version>2.5-optimized3-SNAPSHOT</version>
+    <version>2.5-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: API</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+API+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-api</artifactId>
-    <version>2.5-optimized-SNAPSHOT</version>
+    <version>2.5-optimized2-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: API</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+API+Plugin</url>

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/BodyInvocationAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/BodyInvocationAction.java
@@ -11,7 +11,7 @@ import org.jenkinsci.plugins.workflow.steps.BodyInvoker;
  *
  * @author Kohsuke Kawaguchi
  */
-public class BodyInvocationAction extends InvisibleAction implements FlowNodeAction {
+public class BodyInvocationAction extends InvisibleAction implements FlowNodeAction, PersistentAction {
     /*
      * @param stepBlock
      *      Reference to the block that signifies the enclosing block (which corresponds

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -37,7 +37,7 @@ import hudson.model.Action;
  *
  * @author Kohsuke Kawaguchi
  */
-public class ErrorAction implements Action {
+public class ErrorAction implements PersistentAction {
     private final Throwable error;
 
     public ErrorAction(Throwable error) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/LabelAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/LabelAction.java
@@ -33,7 +33,7 @@ import hudson.model.Action;
  * @author Kohsuke Kawaguchi
  * @author Jesse Glick
  */
-public class LabelAction implements Action {
+public class LabelAction implements PersistentAction {
     private final String displayName;
 
     public LabelAction(String displayName) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/LogAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/LogAction.java
@@ -35,7 +35,7 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
  * Associated with a node which has some log text.
  * So if {@link StepContext} is asked for {@link TaskListener}, the {@link FlowExecution} should attach this action to the contextual {@link FlowNode}.
  */
-public abstract class LogAction implements Action {
+public abstract class LogAction implements PersistentAction {
     /**
      * Access the log file and expose it to the UI with the progressive logging functionality
      */

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/NotExecutedNodeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/NotExecutedNodeAction.java
@@ -12,9 +12,9 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
  *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class NotExecutedNodeAction extends InvisibleAction {
+public class NotExecutedNodeAction extends InvisibleAction implements PersistentAction {
 
     public static boolean isExecuted(FlowNode node) {
-        return (node.getDirectAction(NotExecutedNodeAction.class) == null);
+        return (node.getAction(NotExecutedNodeAction.class) == null);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/NotExecutedNodeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/NotExecutedNodeAction.java
@@ -15,6 +15,6 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 public class NotExecutedNodeAction extends InvisibleAction {
 
     public static boolean isExecuted(FlowNode node) {
-        return (node.getAction(NotExecutedNodeAction.class) == null);
+        return (node.getDirectAction(NotExecutedNodeAction.class) == null);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/NotExecutedNodeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/NotExecutedNodeAction.java
@@ -15,6 +15,6 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 public class NotExecutedNodeAction extends InvisibleAction implements PersistentAction {
 
     public static boolean isExecuted(FlowNode node) {
-        return (node.getDirectAction(NotExecutedNodeAction.class) == null);
+        return (node.getPersistentAction(NotExecutedNodeAction.class) == null);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/NotExecutedNodeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/NotExecutedNodeAction.java
@@ -15,6 +15,6 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 public class NotExecutedNodeAction extends InvisibleAction implements PersistentAction {
 
     public static boolean isExecuted(FlowNode node) {
-        return (node.getAction(NotExecutedNodeAction.class) == null);
+        return (node.getDirectAction(NotExecutedNodeAction.class) == null);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/PersistentAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/PersistentAction.java
@@ -3,8 +3,8 @@ package org.jenkinsci.plugins.workflow.actions;
 import hudson.model.Action;
 
 /**
- * Marker interface for an action that can't be contributed by a {@link jenkins.model.TransientActionFactory}
- * Actions implementing this can use more efficient getAction methods
+ * This is a marker interface for an action that can't be contributed by a {@link jenkins.model.TransientActionFactory}.
+ * Actions implementing this can use more efficient {@link hudson.model.Actionable#getAction(Class)} variant
  */
 public interface PersistentAction extends Action {
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/PersistentAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/PersistentAction.java
@@ -1,0 +1,10 @@
+package org.jenkinsci.plugins.workflow.actions;
+
+import hudson.model.Action;
+
+/**
+ * Marker interface for an action that can't be contributed by a {@link jenkins.model.TransientActionFactory}
+ * Actions implementing this can use more efficient getAction methods
+ */
+public interface PersistentAction extends Action {
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/PersistentAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/PersistentAction.java
@@ -4,7 +4,8 @@ import hudson.model.Action;
 
 /**
  * This is a marker interface for an action that can't be contributed by a {@link jenkins.model.TransientActionFactory}.
- * Actions implementing this can use more efficient {@link hudson.model.Actionable#getAction(Class)} variant
+ * Actions implementing this can use more efficient {@link org.jenkinsci.plugins.workflow.graph.FlowNode#getPersistentAction(Class)}
+ *   and {@link org.jenkinsci.plugins.workflow.graph.FlowNode#getAction(Class)} internally delegates to that
  */
 public interface PersistentAction extends Action {
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/StageAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/StageAction.java
@@ -37,7 +37,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
  * or only within a single thread of an execution (branch of the flow graph).
  * <p>The standard implementation is attached by {@code StageStep} and is linear within an execution (threads are ignored).
  */
-public interface StageAction extends Action {
+public interface StageAction extends PersistentAction {
 
     /**
      * Gets the name of the stage.

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ThreadNameAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ThreadNameAction.java
@@ -32,7 +32,7 @@ import javax.annotation.Nonnull;
  *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public interface ThreadNameAction extends Action {
+public interface ThreadNameAction extends PersistentAction {
 
     @Nonnull
     String getThreadName();

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/TimingAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/TimingAction.java
@@ -42,7 +42,7 @@ public class TimingAction implements Action {
     }
 
     public static long getStartTime(FlowNode flowNode) {
-        TimingAction timingAction = flowNode.getDirectAction(TimingAction.class);
+        TimingAction timingAction = flowNode.getPersistentAction(TimingAction.class);
         if (timingAction != null) {
             return timingAction.getStartTime();
         } else {

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/TimingAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/TimingAction.java
@@ -42,7 +42,7 @@ public class TimingAction implements Action {
     }
 
     public static long getStartTime(FlowNode flowNode) {
-        TimingAction timingAction = flowNode.getDirectAction(TimingAction.class);
+        TimingAction timingAction = flowNode.getAction(TimingAction.class);
         if (timingAction != null) {
             return timingAction.getStartTime();
         } else {

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/TimingAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/TimingAction.java
@@ -42,7 +42,7 @@ public class TimingAction implements Action {
     }
 
     public static long getStartTime(FlowNode flowNode) {
-        TimingAction timingAction = flowNode.getAction(TimingAction.class);
+        TimingAction timingAction = flowNode.getDirectAction(TimingAction.class);
         if (timingAction != null) {
             return timingAction.getStartTime();
         } else {

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/WorkspaceAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/WorkspaceAction.java
@@ -37,7 +37,7 @@ import org.jenkinsci.plugins.workflow.FilePathUtils;
 /**
  * Represents the fact that a step run on a particular workspace.
  */
-public abstract class WorkspaceAction implements Action {
+public abstract class WorkspaceAction implements PersistentAction {
 
     /** The {@link Node#getNodeName} of the workspace. */
     public abstract @Nonnull String getNode();

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecution.java
@@ -198,7 +198,7 @@ public abstract class FlowExecution implements FlowActionStorage {
             return null;
 
         FlowNode e = heads.get(0);
-        ErrorAction error = e.getDirectAction(ErrorAction.class);
+        ErrorAction error = e.getAction(ErrorAction.class);
         if (error==null)    return null;        // successful completion
 
         return error.getError();

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecution.java
@@ -198,7 +198,7 @@ public abstract class FlowExecution implements FlowActionStorage {
             return null;
 
         FlowNode e = heads.get(0);
-        ErrorAction error = e.getDirectAction(ErrorAction.class);
+        ErrorAction error = e.getPersistentAction(ErrorAction.class);
         if (error==null)    return null;        // successful completion
 
         return error.getError();

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecution.java
@@ -198,7 +198,7 @@ public abstract class FlowExecution implements FlowActionStorage {
             return null;
 
         FlowNode e = heads.get(0);
-        ErrorAction error = e.getAction(ErrorAction.class);
+        ErrorAction error = e.getDirectAction(ErrorAction.class);
         if (error==null)    return null;        // successful completion
 
         return error.getError();

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -248,6 +248,26 @@ public abstract class FlowNode extends Actionable implements Saveable {
         this.actions = new CopyOnWriteArrayList<Action>(actions);
     }
 
+
+    // Much faster check of actions because it does not trigger the TransientActionFactory
+    @Override
+    public <T extends Action> T getAction(Class<T> type) {
+        // Need to check and see if this will cause issues -- better to change in place if we can
+        // Otherwise we need to do changes in many places to use a new, fast API
+        List<Action> acts = (actions == null) ? getActions() : actions;
+        for (Action a : acts) {
+            if (type.isInstance(a)) {
+                return type.cast(a);
+            }
+        }
+        return null;
+    }
+
+    // Replaces the legacy getAction method for the few cases we really need it
+    public <T extends Action> T getActionComplete(Class<T> type) {
+        return super.getAction(type);
+    }
+
 /*
     We can't use Actionable#actions to store actions because they aren't transient,
     and we need to store actions elsewhere because this is the only mutable pat of FlowNode.

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -249,9 +249,13 @@ public abstract class FlowNode extends Actionable implements Saveable {
     }
 
 
-    // Much faster check of actions because it does not trigger the TransientActionFactory
-    @Override
-    public <T extends Action> T getAction(Class<T> type) {
+    /**
+     * Return a persistent action o(transient actions are not included)
+     * @param type Action type to look for
+     * @param <T> Action type to look for
+     * @return First attached action of given type, or null if none found
+     */
+    public <T extends Action> T getDirectAction(Class<T> type) {
         // Need to check and see if this will cause issues -- better to change in place if we can
         // Otherwise we need to do changes in many places to use a new, fast API
         List<Action> acts = (actions == null) ? getActions() : actions;
@@ -261,11 +265,6 @@ public abstract class FlowNode extends Actionable implements Saveable {
             }
         }
         return null;
-    }
-
-    // Replaces the legacy getAction method for the few cases we really need it
-    public <T extends Action> T getActionComplete(Class<T> type) {
-        return super.getAction(type);
     }
 
 /*

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -104,7 +104,7 @@ public abstract class FlowNode extends Actionable implements Saveable {
      * This is just a convenience method.
      */
     public final @CheckForNull ErrorAction getError() {
-        return getAction(ErrorAction.class);
+        return getDirectAction(ErrorAction.class);
     }
 
     public @Nonnull FlowExecution getExecution() {
@@ -167,7 +167,7 @@ public abstract class FlowNode extends Actionable implements Saveable {
 
     @Exported
     public String getDisplayName() {
-        LabelAction a = getAction(LabelAction.class);
+        LabelAction a = getDirectAction(LabelAction.class);
         if (a!=null)    return a.getDisplayName();
         else            return getTypeDisplayName();
     }
@@ -177,7 +177,7 @@ public abstract class FlowNode extends Actionable implements Saveable {
         if (functionName == null) {
             return getDisplayName();
         } else {
-            LabelAction a = getAction(LabelAction.class);
+            LabelAction a = getDirectAction(LabelAction.class);
             if (a != null) {
                 return functionName + " (" + a.getDisplayName() + ")";
             } else {

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -107,7 +107,7 @@ public abstract class FlowNode extends Actionable implements Saveable {
      * This is just a convenience method.
      */
     public final @CheckForNull ErrorAction getError() {
-        return getAction(ErrorAction.class);
+        return getDirectAction(ErrorAction.class);
     }
 
     public @Nonnull FlowExecution getExecution() {
@@ -170,7 +170,7 @@ public abstract class FlowNode extends Actionable implements Saveable {
 
     @Exported
     public String getDisplayName() {
-        LabelAction a = getAction(LabelAction.class);
+        LabelAction a = getDirectAction(LabelAction.class);
         if (a!=null)    return a.getDisplayName();
         else            return getTypeDisplayName();
     }
@@ -180,7 +180,7 @@ public abstract class FlowNode extends Actionable implements Saveable {
         if (functionName == null) {
             return getDisplayName();
         } else {
-            LabelAction a = getAction(LabelAction.class);
+            LabelAction a = getDirectAction(LabelAction.class);
             if (a != null) {
                 return functionName + " (" + a.getDisplayName() + ")";
             } else {
@@ -252,7 +252,7 @@ public abstract class FlowNode extends Actionable implements Saveable {
 //            this._wrapper = new ListWrapper(this);
     }
 
-    private  <T extends Action> T getDirectAction(Class<T> type) {
+    public <T extends Action> T getDirectAction(Class<T> type) {
         if (actions == null) {
             loadActions();
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -255,7 +255,7 @@ public abstract class FlowNode extends Actionable implements Saveable {
     /**
      * Return the first nontransient {@link Action} on the FlowNode, without consulting {@link jenkins.model.TransientActionFactory}s
      * <p> This is not restricted to just Actions implementing {@link PersistentAction} but usually they should.
-     * Used here because it is much faster than base {@link ##getAction(Class)} method.
+     * Used here because it is much faster than base {@link #getAction(Class)} method.
      * @param type Class of action
      * @param <T>  Action type
      * @return First nontransient action or null if not found.

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -253,10 +253,11 @@ public abstract class FlowNode extends Actionable implements Saveable {
     }
 
     /**
-     * Return the first persistent action on the FlowNode, without consulting
-     * @param type
-     * @param <T>
-     * @return
+     * Return the first persistent action on the FlowNode, without consulting TransientActionFactories
+     * Used here because it is much faster to invoke a less-conditional, monomorphic method (50% faster)
+     * @param type Class of action
+     * @param <T>  Action type
+     * @return First persistent action or null if not found
      */
     public <T extends Action> T getPersistentAction(@Nonnull Class<T> type) {
         if (actions == null) {
@@ -270,6 +271,7 @@ public abstract class FlowNode extends Actionable implements Saveable {
         return null;
     }
 
+    /** Split out so it can be tightly JIT compiled since the callsite cannot be overridden, benchmarked as a win */
     private <T extends Action> T getMaybeTransientAction(Class<T> type) {
         for (Action a : getAllActions()) {
             if (type.isInstance(a)) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -264,17 +264,21 @@ public abstract class FlowNode extends Actionable implements Saveable {
         return null;
     }
 
+    private <T extends Action> T getMaybeTransientAction(Class<T> type) {
+        for (Action a : getAllActions()) {
+            if (type.isInstance(a)) {
+                return type.cast(a);
+            }
+        }
+        return null;
+    }
+
     @Override
     public <T extends Action> T getAction(Class<T> type) {
         if (PersistentAction.class.isAssignableFrom(type)) {
             return getDirectAction(type);
         } else {
-            for (Action a : getAllActions()) {
-                if (type.isInstance(a)) {
-                    return type.cast(a);
-                }
-            }
-            return null;
+            return getMaybeTransientAction(type);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -263,9 +263,7 @@ public abstract class FlowNode extends Actionable implements Saveable {
     @CheckForNull
     @Restricted(NoExternalUse.class)  // Limit use to workflow-api packages until we have a case where we need the performance badly.
     public final <T extends Action> T getPersistentAction(@Nonnull Class<T> type) {
-        if (actions == null) {
-            loadActions();
-        }
+        loadActions();
         for (Action a : actions) {
             if (type.isInstance(a)) {
                 return type.cast(a);
@@ -299,7 +297,7 @@ public abstract class FlowNode extends Actionable implements Saveable {
 
     private synchronized void loadActions() {
         if (actions != null) {
-            return; //Mutation while we acquired lock
+            return;
         }
         try {
             actions = new CopyOnWriteArrayList<Action>(exec.loadActions(this));
@@ -313,9 +311,8 @@ public abstract class FlowNode extends Actionable implements Saveable {
     @Override
     @SuppressFBWarnings(value = "UG_SYNC_SET_UNSYNC_GET", justification = "CopyOnWrite ArrayList, and field load & modification is synchronized")
     public List<Action> getActions() {
-        if (actions==null) {
-            loadActions();
-        }
+        loadActions();
+
         /*
         We can't use Actionable#actions to store actions because they aren't transient,
         and we need to store actions elsewhere because this is the only mutable part of FlowNode.
@@ -333,13 +330,6 @@ public abstract class FlowNode extends Actionable implements Saveable {
                 public void add(int index, Action element) {
                     actions.add(index, element);
                     persistSafe();
-                }
-
-                @Override
-                public boolean add(Action value) {
-                    actions.add(value);
-                    persistSafe();
-                    return true;
                 }
 
                 @Override

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScanningUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScanningUtils.java
@@ -27,12 +27,6 @@ package org.jenkinsci.plugins.workflow.graphanalysis;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import hudson.model.Action;
-import org.jenkinsci.plugins.workflow.actions.ErrorAction;
-import org.jenkinsci.plugins.workflow.actions.LabelAction;
-import org.jenkinsci.plugins.workflow.actions.LogAction;
-import org.jenkinsci.plugins.workflow.actions.StageAction;
-import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
-import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
 import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
@@ -57,7 +51,7 @@ public final class FlowScanningUtils {
         return new Predicate<FlowNode>() {
             @Override
             public boolean apply(FlowNode input) {
-                return (input != null && input.getDirectAction(actionClass) != null);
+                return (input != null && input.getPersistentAction(actionClass) != null);
             }
         };
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScanningUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScanningUtils.java
@@ -57,7 +57,7 @@ public final class FlowScanningUtils {
         return new Predicate<FlowNode>() {
             @Override
             public boolean apply(FlowNode input) {
-                return (input != null && input.getDirectAction(actionClass) != null);
+                return (input != null && input.getAction(actionClass) != null);
             }
         };
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScanningUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScanningUtils.java
@@ -57,7 +57,7 @@ public final class FlowScanningUtils {
         return new Predicate<FlowNode>() {
             @Override
             public boolean apply(FlowNode input) {
-                return (input != null && input.getAction(actionClass) != null);
+                return (input != null && input.getDirectAction(actionClass) != null);
             }
         };
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScanningUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScanningUtils.java
@@ -51,7 +51,7 @@ public final class FlowScanningUtils {
         return new Predicate<FlowNode>() {
             @Override
             public boolean apply(FlowNode input) {
-                return (input != null && input.getPersistentAction(actionClass) != null);
+                return (input != null && input.getAction(actionClass) != null);
             }
         };
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
@@ -510,7 +510,7 @@ public class ForkScanner extends AbstractFlowScanner {
                     return temp;
                 }
             } else if (!blackList.contains(p)) {
-                if (p instanceof BlockStartNode && p.getAction(ThreadNameAction.class) != null) {
+                if (p instanceof BlockStartNode && p.getDirectAction(ThreadNameAction.class) != null) {
                     nextType = NodeType.PARALLEL_BRANCH_START;
                 } else if (ForkScanner.isParallelEnd(p)) {
                     nextType = NodeType.PARALLEL_END;

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
@@ -39,8 +39,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.ListIterator;
@@ -510,7 +508,7 @@ public class ForkScanner extends AbstractFlowScanner {
                     return temp;
                 }
             } else if (!blackList.contains(p)) {
-                if (p instanceof BlockStartNode && p.getDirectAction(ThreadNameAction.class) != null) {
+                if (p instanceof BlockStartNode && p.getPersistentAction(ThreadNameAction.class) != null) {
                     nextType = NodeType.PARALLEL_BRANCH_START;
                 } else if (ForkScanner.isParallelEnd(p)) {
                     nextType = NodeType.PARALLEL_END;

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
@@ -510,7 +510,7 @@ public class ForkScanner extends AbstractFlowScanner {
                     return temp;
                 }
             } else if (!blackList.contains(p)) {
-                if (p instanceof BlockStartNode && p.getDirectAction(ThreadNameAction.class) != null) {
+                if (p instanceof BlockStartNode && p.getAction(ThreadNameAction.class) != null) {
                     nextType = NodeType.PARALLEL_BRANCH_START;
                 } else if (ForkScanner.isParallelEnd(p)) {
                     nextType = NodeType.PARALLEL_END;

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/LabelledChunkFinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/LabelledChunkFinder.java
@@ -24,7 +24,7 @@ public class LabelledChunkFinder implements ChunkFinder {
     /** Start is anywhere with a {@link LabelAction} */
     @Override
     public boolean isChunkStart(@Nonnull FlowNode current, @CheckForNull FlowNode previous) {
-        LabelAction la = current.getDirectAction(LabelAction.class);
+        LabelAction la = current.getAction(LabelAction.class);
         return la != null;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/LabelledChunkFinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/LabelledChunkFinder.java
@@ -24,7 +24,7 @@ public class LabelledChunkFinder implements ChunkFinder {
     /** Start is anywhere with a {@link LabelAction} */
     @Override
     public boolean isChunkStart(@Nonnull FlowNode current, @CheckForNull FlowNode previous) {
-        LabelAction la = current.getAction(LabelAction.class);
+        LabelAction la = current.getDirectAction(LabelAction.class);
         return la != null;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/LabelledChunkFinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/LabelledChunkFinder.java
@@ -24,7 +24,7 @@ public class LabelledChunkFinder implements ChunkFinder {
     /** Start is anywhere with a {@link LabelAction} */
     @Override
     public boolean isChunkStart(@Nonnull FlowNode current, @CheckForNull FlowNode previous) {
-        LabelAction la = current.getDirectAction(LabelAction.class);
+        LabelAction la = current.getPersistentAction(LabelAction.class);
         return la != null;
     }
 


### PR DESCRIPTION
Implement [JENKINS-38867](https://issues.jenkins-ci.org/browse/JENKINS-38867), which should improve performance significantly (calls to getAction were a significant fraction of flow analysis time, in profiling). 

After extensive benchmarking to find out performance impacts on stage view (the place that feels this pain the worst), optimizations here improve performance 2-3x when doing the first run analysis.

Action items:

- [x] Create a new PersistentAction marker interface
- [x] Set up the getAction(Class) method to look if the action is a PersistentAction, and if so, not inspect transientactionfactories, otherwise fall back to that
- [x] Create a getPersistentAction method on flownode
- [x] Optimizations to the use of the actionable list and its iterator
- [x] Threading stuffs
- [x] Switch the GraphAnalysis APIs to consume getPersistentAction
- [x] Switch internal pipeline APIs to use it too (almost all the time where we're inspecting nodes)
- [x] Various painful micro-optimizations which offer another ~10% performance gain and probably in other places (worth it because the API is hit hard in pipeline)
- [x] Set up workflow support downstream PR to mark PauseAction as a PersistentAction - https://github.com/jenkinsci/workflow-support-plugin/pull/17
- [x] Benchmark the difference to confirm impact (in progress). - 50-66% reduction in run handling for stage view.

Related to https://github.com/jenkinsci/jenkins/pull/2582 but pipeline specific and does not require core bump.