### PR TITLE
Use readResolve to deduplicate FlowNode IDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-api</artifactId>
-    <!-- For downstream deps -- changed upon release --> 
+    <!-- For downstream deps, changed upon release --> 
     <version>2.6-dedup-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: API</name>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,8 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-api</artifactId>
-    <version>2.6-SNAPSHOT</version>
+    <!-- For downstream deps -- changed upon release --> 
+    <version>2.6-dedup-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: API</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+API+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-api</artifactId>
-    <!-- For downstream deps, changed upon release --> 
-    <version>2.6-dedup-SNAPSHOT</version>
+    <version>2.6-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: API</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+API+Plugin</url>

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -59,10 +59,10 @@ import org.kohsuke.stapler.export.ExportedBean;
  */
 @ExportedBean
 public abstract class FlowNode extends Actionable implements Saveable {
-    protected transient List<FlowNode> parents;
-    protected List<String> parentIds;
+    private transient List<FlowNode> parents;
+    private List<String> parentIds;
 
-    protected String id;
+    private String id;
 
     // this is a copy-on-write array so synchronization isn't needed between reader & writer.
     @edu.umd.cs.findbugs.annotations.SuppressWarnings("IS2_INCONSISTENT_SYNC")

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -59,10 +59,10 @@ import org.kohsuke.stapler.export.ExportedBean;
  */
 @ExportedBean
 public abstract class FlowNode extends Actionable implements Saveable {
-    private transient List<FlowNode> parents;
-    private final List<String> parentIds;
+    protected transient List<FlowNode> parents;
+    protected List<String> parentIds;
 
-    private String id;
+    protected String id;
 
     // this is a copy-on-write array so synchronization isn't needed between reader & writer.
     @edu.umd.cs.findbugs.annotations.SuppressWarnings("IS2_INCONSISTENT_SYNC")
@@ -92,7 +92,7 @@ public abstract class FlowNode extends Actionable implements Saveable {
         return ids;
     }
 
-    private Object readResolve() throws ObjectStreamException {
+    protected Object readResolve() throws ObjectStreamException {
         // Ensure we deduplicate strings upon deserialization
         if (this.id != null) {
             this.id = this.id.intern();


### PR DESCRIPTION
Should reduce memory footprint for Jenkins pipeline a bit and simplify garbage collection some. 

See [JENKINS-39456](https://issues.jenkins-ci.org/browse/JENKINS-39456)

Replaces https://github.com/jenkinsci/workflow-support-plugin/pull/24