### PR TITLE
Add StepNode to support fetching StepDescriptor at higher level of API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-api</artifactId>
-    <version>2.9</version>
+    <version>2.10-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: API</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+API+Plugin</url>
@@ -47,7 +47,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>workflow-api-2.9</tag>
+      <tag>HEAD</tag>
     </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-api</artifactId>
     <!-- Temporary version to allow use in related PRs, will revert before merge -->
-    <version>2.9-stepnode-SNAPSHOT</version>
+    <version>2.9-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: API</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+API+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-api</artifactId>
-    <version>2.10-SNAPSHOT</version>
+    <version>2.9</version>
     <packaging>hpi</packaging>
     <name>Pipeline: API</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+API+Plugin</url>
@@ -47,7 +47,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
+      <tag>workflow-api-2.9</tag>
     </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-api</artifactId>
-    <version>2.9-SNAPSHOT</version>
+    <version>2.9</version>
     <packaging>hpi</packaging>
     <name>Pipeline: API</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+API+Plugin</url>
@@ -47,7 +47,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
+      <tag>workflow-api-2.9</tag>
     </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,8 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-api</artifactId>
-    <version>2.9-SNAPSHOT</version>
+    <!-- Temporary version to allow use in related PRs, will revert before merge -->
+    <version>2.9-stepnode-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: API</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+API+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-api</artifactId>
-    <!-- Temporary version to allow use in related PRs, will revert before merge -->
     <version>2.9-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: API</name>

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/StepNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/StepNode.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.workflow.graph;
+
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+
+import javax.annotation.CheckForNull;
+
+/**
+ * Optional interface for a {@link FlowNode} that has an associated {@link StepDescriptor}.
+ * Supertype of the equivalent in the workflow-cps to allow access at a higher level of the dependency tree.
+ */
+public interface StepNode {
+    /**
+     * Returns the descriptor for {@link Step} that produced this flow node.
+     *
+     * @return
+     *      null for example if the descriptor that created the node has since been uninstalled.
+     */
+    @CheckForNull
+    StepDescriptor getDescriptor();
+}


### PR DESCRIPTION
Upstream of https://github.com/jenkinsci/workflow-cps-plugin/pull/104

This permits us to obtain the StepDescriptor without taking a dependency on workflow-cps -- needed for some APIs. 

@reviewbybees 