### PR TITLE
Lift up the rock on graphanalysis visitor API (testcase) and fix the bugs crawling underneath + documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.2</version>
+            <version>2.26</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/AbstractFlowScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/AbstractFlowScanner.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.workflow.graphanalysis;
 
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
@@ -305,6 +306,25 @@ public abstract class AbstractFlowScanner implements Iterable <FlowNode>, Filter
             }
         }
         return nodes;
+    }
+
+    /** Convenience method to get the list all flownodes in the iterator order. */
+    @Nonnull
+    public List<FlowNode> allNodes(@CheckForNull Collection<FlowNode> heads) {
+        if (!setup(heads)) {
+            return Collections.EMPTY_LIST;
+        }
+        List<FlowNode> nodes = new ArrayList<FlowNode>();
+        for (FlowNode f : this) {
+            nodes.add(f);
+        }
+        return nodes;
+    }
+
+    /** Convenience method to get the list of all {@link FlowNode}s for the execution, in iterator order. */
+    @Nonnull
+    public List<FlowNode> allNodes(@CheckForNull FlowExecution exec) {
+        return (exec == null) ? Collections.EMPTY_LIST : allNodes(exec.getCurrentHeads());
     }
 
     /** Syntactic sugar for {@link #filteredNodes(Collection, Collection, Predicate)} with no blackList nodes */

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/BlockChunkFinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/BlockChunkFinder.java
@@ -8,11 +8,13 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 /**
- * Matches start and end of a block.  Any block
+ * Matches start and end of a block.  Any block!
  * @author Sam Van Oort
  */
 public class BlockChunkFinder implements ChunkFinder {
 
+    /** NOTE: you will need to handle cases where you have a start node where the end node has not been generated yet!
+     *  This means you need to keep nodes around even after hitting the EndNode */
     @Override
     public boolean isStartInsideChunk() {
         return false;

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ChunkFinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ChunkFinder.java
@@ -6,13 +6,34 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 /**
- * Used to define the start and end of a {@link FlowChunk} to split a {@link org.jenkinsci.plugins.workflow.flow.FlowExecution}
- * (For use with a {@link SimpleChunkVisitor} in the {@link ForkScanner#visitSimpleChunks(SimpleChunkVisitor, ChunkFinder)}
+ * Think of this as setting conditions to mark a region of interest in the graph of {@link FlowNode} from a {@link org.jenkinsci.plugins.workflow.flow.FlowExecution}.
+ * <p>This is used to define a linear "chunk" from the graph of FlowNodes returned by a {@link ForkScanner}, after it applies ordering.
+ * <p>This is done by invoking {@link ForkScanner#visitSimpleChunks(SimpleChunkVisitor, ChunkFinder)}.
+ * <p>Your {@link SimpleChunkVisitor} will receive callbacks about chunk boundaries on the basis of the ChunkFinder.
+ *   It isresponsible for tracking the state based on events fired
+ *
+ * <p><p><em>Common uses:</em>
+ * <ul>
+ *     <li>Find all nodes within a specific block type, such the block created by a timeout block, 'node' (executor) block, etc</li>
+ *     <li>Find all nodes between specific markers, such as labels, milestones, or steps generating an error</li>
+ * </ul>
+ *
+ * <p><em>Implementation Notes:</em>
+ * <ul>
+ *     <li>This can be used to detect both block-delimited regions of interest and marker-based regions</li>
+ *     <li>Block-delimited regions should END when encountering the right kind of {@link org.jenkinsci.plugins.workflow.graph.BlockEndNode}
+ *         and start when seeing the right kind of {@link org.jenkinsci.plugins.workflow.graph.BlockStartNode}</li>
+ *     <li>Marker-based regions should start when you find the marker, and END when the previous node is a marker</li>
+ *     <li>If you need to handle both for the same set of criteria... good grief. See the StageChunkFinder in the pipeline-graph-analysis plugin.</li>
+ * </ul>
+ *
  * @author Sam Van Oort
  */
 public interface ChunkFinder {
 
-    /** If true, a chunk is implicitly created whenever we begin */
+    /** If true, a chunk is implicitly created whenever we begin.
+     *  <p>If you are matching the start/end of a block, should always return false.
+     *  <p>If you are trying to match markers (such as single-node labels or milestones), should always be true. */
     boolean isStartInsideChunk();
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScanningUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScanningUtils.java
@@ -82,6 +82,22 @@ public final class FlowScanningUtils {
         };
     };
 
+    public static final Comparator<FlowNode> ID_ORDER_COMPARATOR = new Comparator<FlowNode>() {
+        /** Implements null checking because the use of this method will not easily permit FindBugs verification on NonNull*/
+        public int compare(@CheckForNull FlowNode first, @CheckForNull FlowNode second) {
+            if (first == null || second == null) {
+                return 0;
+            }
+            try {
+                int id1 = Integer.parseInt(first.getId());
+                int id2 = Integer.parseInt(second.getId());
+                return Integer.compare(id1, id2);
+            } catch (NumberFormatException nfe) {
+                return first.getId().compareTo(second.getId());
+            }
+        };
+    };
+
     /**
      * Returns all {@link BlockStartNode}s enclosing the given FlowNode, starting from the inside out.
      * This is useful if we want to obtain information about its scope, such as the workspace, parallel branch, or label.

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScanningUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScanningUtils.java
@@ -27,10 +27,13 @@ package org.jenkinsci.plugins.workflow.graphanalysis;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import hudson.model.Action;
+import org.jenkinsci.plugins.workflow.actions.TimingAction;
 import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import java.util.Comparator;
 
 /**
  * Library of common functionality when analyzing/walking flow graphs
@@ -58,6 +61,26 @@ public final class FlowScanningUtils {
 
     // Default predicates, which may be used for common conditions
     public static final Predicate<FlowNode> MATCH_BLOCK_START = (Predicate)Predicates.instanceOf(BlockStartNode.class);
+
+    /** Sorts flownodes putting the one begun last (oldest startTime) at the end, with null times last
+     *  because likely they represent the newest nodes with a {@link TimingAction} not attached yet. */
+    public static final Comparator<FlowNode> TIME_ORDER_COMPARATOR = new Comparator<FlowNode>() {
+        /** Implements null checking because the use of this method will not easily permit FindBugs verification on NonNull*/
+        public int compare(@CheckForNull FlowNode first, @CheckForNull FlowNode second) {
+            if (first == null || second == null) {
+                return 0;  // Sorting by start time is 100% irrelevant
+            }
+            TimingAction timingFirst = first.getPersistentAction(TimingAction.class);
+            TimingAction timingSecond = second.getPersistentAction(TimingAction.class);
+            if (timingFirst != null && timingSecond != null) {
+                return Long.compare(timingFirst.getStartTime(), timingSecond.getStartTime());
+            } else if (timingFirst == null && timingSecond == null) {
+                return 0;
+            } else { // Only one is null, that one should return the greater value
+                return (timingSecond == null) ? -1 : 1 ;
+            }
+        };
+    };
 
     /**
      * Returns all {@link BlockStartNode}s enclosing the given FlowNode, starting from the inside out.

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
@@ -25,7 +25,6 @@
 package org.jenkinsci.plugins.workflow.graphanalysis;
 
 import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
 import com.google.common.collect.Lists;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.actions.TimingAction;
@@ -154,10 +153,9 @@ public class ForkScanner extends AbstractFlowScanner {
             return object != null && object instanceof IsParallelPredicate;
         }
     }
-    
-    // A bit of a dirty hack, but it works around the fact that we need trivial access to classes from workflow-cps
-    // For this and only this test. So, we load them from a context that is aware of them.
-    // Ex: workflow-cps can automatically set this correctly. Not perfectly graceful but it works.
+
+    /** Originally a workaround to deal with needing the {@link StepDescriptor} to determine if a node is a parallel start
+     *  Now tidily solved by {@link IsParallelPredicate}*/
     private static Predicate<FlowNode> parallelStartPredicate = new IsParallelPredicate();
 
     // Invoke this passing a test against the ParallelStep conditions
@@ -619,6 +617,7 @@ public class ForkScanner extends AbstractFlowScanner {
     /** Trivial sorting of the current in-progress branches (See issue JENKINS-38536)... does not handle nesting correctly though */
     void sortParallelByTime() {
         // FIXME add nesting support by storing a full tree structure for branches and not the overly complex queue system
+        // FIXME this is horribly broken!!
         if (this.currentParallelStart == null) {  // Not in parallel
             return;
         }
@@ -640,7 +639,7 @@ public class ForkScanner extends AbstractFlowScanner {
         // We can't just  fire the extra chunkEnd event
         // We need to look at the parallels structure, and for each parallel re-sort the nodes by their timing info...
         // IFF they are open when beginning (if complete, it is irrelevant)
-        sortParallelByTime();
+//        sortParallelByTime();
         boolean needsEnd = false;
         if (finder.isStartInsideChunk()) {
             needsEnd = true;

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
@@ -135,7 +135,7 @@ public class ForkScanner extends AbstractFlowScanner {
     /** Works with workflow-cps 2.26 and up, otherwise you'll need to provide your own predicate
      *   However this is better than the previous (always false predicate).
      */
-    public static class IsParallelPredicate implements Predicate<FlowNode> {
+    public static class IsParallelStartPredicate implements Predicate<FlowNode> {
         static final String PARALLEL_DESCRIPTOR_CLASSNAME = "org.jenkinsci.plugins.workflow.cps.steps.ParallelStep";
 
         @Override
@@ -144,19 +144,19 @@ public class ForkScanner extends AbstractFlowScanner {
                 return false;
             } else {
                 StepDescriptor desc = ((StepNode)input).getDescriptor();
-                return desc != null && PARALLEL_DESCRIPTOR_CLASSNAME.equals(desc.getId());
+                return desc != null && PARALLEL_DESCRIPTOR_CLASSNAME.equals(desc.getId()) && input.getPersistentAction(ThreadNameAction.class) == null;
             }
         }
 
         @Override
         public boolean equals(@Nullable Object object) {
-            return object != null && object instanceof IsParallelPredicate;
+            return object != null && object instanceof IsParallelStartPredicate;
         }
     }
 
     /** Originally a workaround to deal with needing the {@link StepDescriptor} to determine if a node is a parallel start
-     *  Now tidily solved by {@link IsParallelPredicate}*/
-    private static Predicate<FlowNode> parallelStartPredicate = new IsParallelPredicate();
+     *  Now tidily solved by {@link IsParallelStartPredicate}*/
+    private static Predicate<FlowNode> parallelStartPredicate = new IsParallelStartPredicate();
 
     // Invoke this passing a test against the ParallelStep conditions
     public static void setParallelStartPredicate(@Nonnull Predicate<FlowNode> pred) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
@@ -506,6 +506,8 @@ public class ForkScanner extends AbstractFlowScanner {
 
     @Override
     protected void setHeads(@Nonnull Collection<FlowNode> heads) {
+        // FIXME I need to do something with the tips, similar to what we do in nextTree if they're normal-type
+        // Otherwise NPEs
         if (heads.size() > 1) {
             this.currentChunkNode = buildParallelStructure(new LinkedHashSet<FlowNode>(heads));
             assert this.currentChunkNode != null;
@@ -613,6 +615,7 @@ public class ForkScanner extends AbstractFlowScanner {
                     BlockStartNode parallelStart = ((BlockEndNode)plannedNext).getStartNode();
                     ChunkTreeNode parallelBlock = null;
                     if (currentTreeNode == null || currentTreeNode.findEnclosingNode(parallelStart) == null) {
+                        // FIXME this is wrong.
                         // Found an untracked parallel block
                         parallelBlock = new ChunkTreeNode((BlockEndNode)plannedNext);
                     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
@@ -133,6 +133,9 @@ public class ForkScanner extends AbstractFlowScanner {
         myNext = null;
     }
 
+    /** Works with workflow-cps 2.26 and up, otherwise you'll need to provide your own predicate
+     *   However this is better than the previous (always false predicate).
+     */
     public static class IsParallelPredicate implements Predicate<FlowNode> {
         static final String PARALLEL_DESCRIPTOR_CLASSNAME = "org.jenkinsci.plugins.workflow.cps.steps.ParallelStep";
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ParallelMemoryFlowChunk.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ParallelMemoryFlowChunk.java
@@ -28,8 +28,8 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -52,6 +52,16 @@ public class ParallelMemoryFlowChunk extends MemoryFlowChunk implements Parallel
 
     public void setBranch(@Nonnull String branchName, @Nonnull MemoryFlowChunk branchBlock) {
         branches.put(branchName, branchBlock);
+    }
+
+    /** Return the collection of all branches in an iterable fashion */
+    public Collection<MemoryFlowChunk> getBranchList() {
+        return branches.values();
+    }
+
+    /** Clear out all branches to avoid holding pointers */
+    public void clearBranches() {
+        branches.clear();
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/SimpleChunkVisitor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/SimpleChunkVisitor.java
@@ -49,9 +49,10 @@ import javax.annotation.Nonnull;
  * <p><p><em>Chunk callback rules:</em>
  * <ol>
  *     <li>For a single node, it may have EITHER OR BOTH chunkStart and chunkEnd events</li>
+ *     <li>Every node that doesn't get a startChunk/endChunk callback gets an atomNode callback.</li>
  *     <li>For {@link ChunkFinder} implementations that match the {@link BlockStartNode} and {@link BlockEndNode} should never have both for a single</li>
- *     <li>You cannot have multiple of any of these callbacks for the same flownode</li>
- *     <li>You cannot have a atomNode callback AND a start/end for the same flownode</li>
+ *     <li>You cannot have multiple of any of the same specific type of callbacks for the same flownode</li>
+ *     <li>You cannot have a atomNode callback AND a start/end for the same flownode (application of the above).</li>
  * </ol>
  *
  * <p>Parallel Structure Callbacks: Zero, One, or Multiple may be invoked for any given FlowNode</p>

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/SimpleChunkVisitor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/SimpleChunkVisitor.java
@@ -39,12 +39,20 @@ import javax.annotation.Nonnull;
  *
  * <p><em>Callback types</em>
  * <p> There are two kinds of callbacks - chunk callbacks, and parallel structure callbacks
- * <p> Chunk Callbacks: only ONE of these can be invoked for a given {@link FlowNode}, and <em>every</em> FlowNode gets one.</p>
+ * <p><em>Chunk Callbacks:</em>
  * <ul>
  *     <li>{@link #chunkStart(FlowNode, FlowNode, ForkScanner)} - detected the start of a chunk beginning with a node</li>
  *     <li>{@link #chunkEnd(FlowNode, FlowNode, ForkScanner)} - detected the end of a chunk, terminating with a node </li>
  *     <li>{@link #atomNode(FlowNode, FlowNode, FlowNode, ForkScanner)} - most nodes, which aren't boundaries of chunks</li>
  * </ul>
+ *
+ * <p><p><em>Chunk callback rules:</em>
+ * <ol>
+ *     <li>For a single node, it may have EITHER OR BOTH chunkStart and chunkEnd events</li>
+ *     <li>For {@link ChunkFinder} implementations that match the {@link BlockStartNode} and {@link BlockEndNode} should never have both for a single</li>
+ *     <li>You cannot have multiple of any of these callbacks for the same flownode</li>
+ *     <li>You cannot have a atomNode callback AND a start/end for the same flownode</li>
+ * </ol>
  *
  * <p>Parallel Structure Callbacks: Zero, One, or Multiple may be invoked for any given FlowNode</p>
  * <p>These are used to provide awareness of parallel/branching structures if they need special handling

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/SimpleChunkVisitor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/SimpleChunkVisitor.java
@@ -34,25 +34,33 @@ import javax.annotation.Nonnull;
  * This visitor's callbacks are invoked as we walk through a pipeline flow graph, and it splits it into chunks.
  * <p> A {@link ForkScanner#visitSimpleChunks(SimpleChunkVisitor, ChunkFinder)} creates these FlowChunks using a {@link ChunkFinder} to define the chunk boundaries.
  *
- * <p> Implementations get to decide how to use and handle chunks.
- * <p> <h3>At a minimum they should handle:</h3>
+ * <p>We walk through the {@link FlowNode}s in reverse order from end to start, so <em>end callbacks are invoked before
+ *  their corresponding start callbacks.</em>
+ *
+ * <p><em>Callback types</em>
+ * <p> There are two kinds of callbacks - chunk callbacks, and parallel structure callbacks
+ * <p> Chunk Callbacks: only ONE of these can be invoked for a given {@link FlowNode}, and <em>every</em> FlowNode gets one.</p>
  * <ul>
- *     <li>Unbalanced numbers of chunk start/end calls (for incomplete flows)</li>
- *     <li>A chunk end with no beginning (runs to start of flow, or never began)</li>
- *     <li>A chunk start with no end (ex: a block that hasn't completed running)</li>
- *     <li>Other starts/ends before we hit the closing one (nesting)</li>
- *     <li>Atom nodes not within the current Chunk (visitor is responsible for handling state)</li>
+ *     <li>{@link #chunkStart(FlowNode, FlowNode, ForkScanner)} - detected the start of a chunk beginning with a node</li>
+ *     <li>{@link #chunkEnd(FlowNode, FlowNode, ForkScanner)} - detected the end of a chunk, terminating with a node </li>
+ *     <li>{@link #atomNode(FlowNode, FlowNode, FlowNode, ForkScanner)} - most nodes, which aren't boundaries of chunks</li>
  * </ul>
  *
- * <em>Important implementation note: multiple callbacks can be invoked for a single node depending on its type.</em>
- * <p>For example, we may capture parallels as chunks.
- *
- * <p><h3>Callbacks Reporting on chunk/parallel information:</h3>
+ * <p>Parallel Structure Callbacks: Zero, One, or Multiple may be invoked for any given FlowNode</p>
+ * <p>These are used to provide awareness of parallel/branching structures if they need special handling
  * <ul>
- *     <li>{@link #chunkStart(FlowNode, FlowNode, ForkScanner)} is called on the current node when we hit start of a boundary (inclusive) </li>
- *     <li>{@link #chunkEnd(FlowNode, FlowNode, ForkScanner)} is called when we hit end of a boundary (inclusive)</li>
- *     <li>{@link #atomNode(FlowNode, FlowNode, FlowNode, ForkScanner)} called when a node is neither start nor end.</li>
- *     <li>All the parallel methods are used to report on parallel status - helpful when we need to deal with parallels internal to chunks.</li>
+ *     <li>{@link #parallelStart(FlowNode, FlowNode, ForkScanner)}</li>
+ *     <li>{@link #parallelEnd(FlowNode, FlowNode, ForkScanner)}</li>
+ *     <li>{@link #parallelBranchStart(FlowNode, FlowNode, ForkScanner)}</li>
+ *     <li>{@link #parallelBranchEnd(FlowNode, FlowNode, ForkScanner)}</li>
+ * </ul>
+ *
+ * <p>Implementations get to decide how to use and handle chunks, and should be stateful.
+ * <p><h3>At a minimum they should handle:</h3>
+ * <ul>
+ *     <li>Cases where there is no enclosing chunk (no start/end found, or outside a chunk)</li>
+ *     <li>Cases where there is no chunk end to match the start, because we haven't finished running a block</li>
+ *     <li>Nesting of chunks</li>
  * </ul>
  *
  * @author Sam Van Oort

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/package-info.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/package-info.java
@@ -13,6 +13,27 @@
  *     <li><em>Visit every block in a predictable order, from end to start?</em> {@link org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner}</li>
  *     <li><em>Fastest way to find preceding sibling or enclosing nodes?</em> {@link org.jenkinsci.plugins.workflow.graphanalysis.LinearBlockHoppingScanner}</li>
  * </ol>
+ *
+ * <p> Methods to iterate through flow graph and break it into chunks (regions) of interest, with nesting possible & reporting of branches:
+ * <p><em>Basic APIs</em>
+ * <ol>
+ *     <li>{@link org.jenkinsci.plugins.workflow.graphanalysis.ChunkFinder} - API to define conditions for starting/ending a chunk</li>
+ *     <li>{@link org.jenkinsci.plugins.workflow.graphanalysis.SimpleChunkVisitor} - Visitor API that accepts callbacks for chunk boundaries/contenst + parallel branching</li>
+ *     <li>{@link org.jenkinsci.plugins.workflow.graphanalysis.FlowChunk} - A region of interest, defined by its first and last nodes</li>
+ *     <li>{@link org.jenkinsci.plugins.workflow.graphanalysis.FlowChunkWithContext} - A FlowChunk that knows about the nodes before/after it,
+ *          to give context for determining success/failure and the time taken to execute</li>
+ * </ol>
+ *
+ * <p><em>Data structures and implementations:</em>
+ * <ul>
+ *     <li>{@link org.jenkinsci.plugins.workflow.graphanalysis.MemoryFlowChunk} - A FlowChunkWithContext that just directly stores FlowNodes</li>
+ *     <li>{@link org.jenkinsci.plugins.workflow.graphanalysis.ParallelFlowChunk}</li>
+ *     <li>{@link org.jenkinsci.plugins.workflow.graphanalysis.ParallelMemoryFlowChunk}</li>
+ *     <li>{@link org.jenkinsci.plugins.workflow.graphanalysis.StandardChunkVisitor} - a basic concrete implementation of SimpleChunkVisitor that
+ *                tracks one chunk at a time (no nesting) and runs a callback when the chunk is done</li>
+ *     <li>{@link org.jenkinsci.plugins.workflow.graphanalysis.LabelledChunkFinder} - ChunkFinder that matches against nodes with a label</li>
+ *     <li>{@link org.jenkinsci.plugins.workflow.graphanalysis.BlockChunkFinder} - ChunkFinder that creates chunks from blocks</li>
+ * </ul>
  */
 
 package org.jenkinsci.plugins.workflow.graphanalysis;

--- a/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/ChunkFinderWithoutChunks.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/ChunkFinderWithoutChunks.java
@@ -1,0 +1,26 @@
+package org.jenkinsci.plugins.workflow.graphanalysis;
+
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+/**
+ * For test use: a ChunkFinder that never returns chunks, to use in testing parallel handling only.
+ */
+public class ChunkFinderWithoutChunks implements ChunkFinder {
+    @Override
+    public boolean isStartInsideChunk() {
+        return false;
+    }
+
+    @Override
+    public boolean isChunkStart(@Nonnull FlowNode current, @CheckForNull FlowNode previous) {
+        return false;
+    }
+
+    @Override
+    public boolean isChunkEnd(@Nonnull FlowNode current, @CheckForNull FlowNode previous) {
+        return false;
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScannerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScannerTest.java
@@ -171,13 +171,6 @@ public class ForkScannerTest {
         this.NESTED_PARALLEL_RUN = b;
     }
 
-    public static Predicate<FlowNode> PARALLEL_START_PREDICATE = new Predicate<FlowNode>() {
-        @Override
-        public boolean apply(FlowNode input) {
-            return input != null && input instanceof StepStartNode && (((StepStartNode) input).getDescriptor().getClass() == ParallelStep.DescriptorImpl.class);
-        }
-    };
-
     /** Runs some basic sanity tests of iteration and visitor use */
     private void sanityTestIterationAndVisiter(List<FlowNode> heads) throws Exception {
         ForkScanner scan = new ForkScanner();
@@ -200,7 +193,6 @@ public class ForkScannerTest {
         // Initial case
         ForkScanner scanner = new ForkScanner();
         scanner.setup(heads, null);
-        ForkScanner.setParallelStartPredicate(PARALLEL_START_PREDICATE);
         Assert.assertNull(scanner.currentParallelStart);
         Assert.assertNull(scanner.currentParallelStartNode);
         Assert.assertNotNull(scanner.parallelBlockStartStack);
@@ -504,7 +496,6 @@ public class ForkScannerTest {
     /** For nodes, see {@link #SIMPLE_PARALLEL_RUN} */
     @Test
     public void testSimpleVisitor() throws Exception {
-        ForkScanner.setParallelStartPredicate(PARALLEL_START_PREDICATE);
         FlowExecution exec = this.SIMPLE_PARALLEL_RUN.getExecution();
         ForkScanner f = new ForkScanner();
         f.setup(exec.getCurrentHeads());
@@ -570,11 +561,6 @@ public class ForkScannerTest {
         new TestVisitor.CallEntry(TestVisitor.CallType.PARALLEL_START, 4, 6).assertEquals(parallelCalls.get(5));
     }
 
-    @Before
-    public void setupParallelStartPredicate() {
-        ForkScanner.setParallelStartPredicate(PARALLEL_START_PREDICATE);
-    }
-
     /** Checks for off-by one cases with multiple parallel, and with the leastCommonAncestor */
     @Test
     public void testTripleParallel() throws Exception {
@@ -590,8 +576,6 @@ public class ForkScannerTest {
                 "}" // Node 15 is UI branch end node, Node 16 is Parallel End node, Node 17 is FlowWendNode
         ));
         WorkflowRun b = r.assertBuildStatusSuccess(job.scheduleBuild2(0));
-
-        ForkScanner.setParallelStartPredicate(PARALLEL_START_PREDICATE);
         FlowExecution exec = b.getExecution();
         ForkScanner f = new ForkScanner();
         List<FlowNode> heads = exec.getCurrentHeads();

--- a/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/TestVisitor.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/TestVisitor.java
@@ -282,7 +282,8 @@ public class TestVisitor implements SimpleChunkVisitor {
         // First check every parallel with branch starts *also* has branch ends and the same number of them
         for (Map.Entry<Integer, List<Integer>> startEntry : branchStartIds.entrySet()) {
             List<Integer> ends = branchEndIds.get(startEntry.getKey());
-            Assert.assertNotNull("Parallels with a branch start event(s) but no branch end event(s), parallel start node id: "+startEntry.getKey(), ends);
+            // Branch start without branch end is legal due to incomplete flows
+//            Assert.assertNotNull("Parallels with a branch start event(s) but no branch end event(s), parallel start node id: "+startEntry.getKey(), ends);
             Assert.assertEquals("Parallels must have matching numbers of start and end events, but don't -- for parallel starting with: "+
                 startEntry.getKey(), startEntry.getValue().size(), ends.size());
         }


### PR DESCRIPTION
**WILL NOT BUILD YET**

**Addresses:**

- [ ] Fix the ordering for *un-nested* parallels ordering for the visitor (add more exhaustive sorting of branches at the top-level branch) - [JENKINS-38536](https://issues.jenkins-ci.org/browse/JENKINS-38536)
- [ ] Create JIRA RFE for supporting sorting of nested branch ends with visitor -- needs internal datastructure rewrites though to support this case
- [x] Clean up & extend javadocs to fully explain the visitor (SAX-like) APIs for graphanalysis, aka Bismuth Level 2, 
- [x] Document the rules and assumptions for visitor APIs, and add test coverage to verify they are correctly implemented, in depth
- [x] Fix and testcases for fix of [JENKINS-41685](https://issues.jenkins-ci.org/browse/JENKINS-41685) (duplicate events)
- [ ] Manually test to verify duplicate event solved there too
- [x] Sanity-test case for [JENKINS-39841](https://issues.jenkins-ci.org/browse/JENKINS-39841) in the TestVisitor -- nulls where there shouldn't be
- [x] Verify testcase added for [JENKINS-39839](https://issues.jenkins-ci.org/browse/JENKINS-39839) - missing parallel events with nesting
- [x] Code cleanup / streamlining / refactoring in ForkScanner
