### PR TITLE
Introduced FlowCopier.StandardActions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@
             <version>2.7</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>1.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
             <version>2.9</version>


### PR DESCRIPTION
Found that `ParametersAction` and `SCMRevisionAction` were not getting properly copied from one build to the next.

@reviewbybees