### PR TITLE
Fix a ForkScanner sanity check failing with a specific case of zero-branch parallels [JENKINS-42895]

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
@@ -550,9 +550,7 @@ public class ForkScanner extends AbstractFlowScanner {
                 }
             }
         } else {
-            if (isWalkingFromFinish()) {  //Incomplete single-branch parallels can do this
-                throw new IllegalStateException("Hit a BlockStartNode with no record of the start!");
-            }
+            // Incomplete single-branch parallel, or worse, a 0-branch parallel
             return myCurrent.getParents().get(0); // No branches to explore
         }
 


### PR DESCRIPTION
Which results in a user-visible error -- see [JENKINS-42895](https://issues.jenkins-ci.org/browse/JENKINS-42895). 

@reviewbybees unless this introduces a failure in one of the unrelated tests.