### PR TITLE
[JENKINS-43055] Add FlowExecutionListener ExtensionPoint.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
@@ -4,7 +4,7 @@ import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 
 /**
- * Listens for significant status updates for a {@link FlowExecution}, such as started running, paused, or completed.
+ * Listens for significant status updates for a {@link FlowExecution}, such as started running or completed.
  *
  * @since 2.14
  * @author Andrew Bayer
@@ -17,14 +17,6 @@ public abstract class FlowExecutionListener implements ExtensionPoint {
      * @param execution The {@link FlowExecution} that has started running or resumed.
      */
     public void onRunning(FlowExecution execution) {
-    }
-
-    /**
-     * Called when a {@link FlowExecution} has paused.
-     *
-     * @param execution The {@link FlowExecution} that has paused.
-     */
-    public void onPaused(FlowExecution execution) {
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
@@ -27,11 +27,4 @@ public abstract class FlowExecutionListener implements ExtensionPoint {
     public void onCompleted(FlowExecution execution) {
     }
 
-    /**
-     * All the registered {@link FlowExecutionListener}s.
-     */
-    public static ExtensionList<FlowExecutionListener> all() {
-        return ExtensionList.lookup(FlowExecutionListener.class);
-    }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.workflow.flow;
 
-import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 
 /**
@@ -15,8 +14,9 @@ public abstract class FlowExecutionListener implements ExtensionPoint {
      * Called when a {@link FlowExecution} has started running or resumed.
      *
      * @param execution The {@link FlowExecution} that has started running or resumed.
+     * @param resumed True the execution is resuming, false if it's starting for the first time.
      */
-    public void onRunning(FlowExecution execution) {
+    public void onRunning(FlowExecution execution, boolean resumed) {
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
@@ -1,0 +1,45 @@
+package org.jenkinsci.plugins.workflow.flow;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+
+/**
+ * Listens for significant status updates for a {@link FlowExecution}, such as started running, paused, or completed.
+ *
+ * @since 2.14
+ * @author Andrew Bayer
+ */
+public abstract class FlowExecutionListener implements ExtensionPoint {
+
+    /**
+     * Called when a {@link FlowExecution} has started running or resumed.
+     *
+     * @param execution The {@link FlowExecution} that has started running or resumed.
+     */
+    public void onRunning(FlowExecution execution) {
+    }
+
+    /**
+     * Called when a {@link FlowExecution} has paused.
+     *
+     * @param execution The {@link FlowExecution} that has paused.
+     */
+    public void onPaused(FlowExecution execution) {
+    }
+
+    /**
+     * Called when a {@link FlowExecution} has completed.
+     *
+     * @param execution The {@link FlowExecution} that has completed.
+     */
+    public void onCompleted(FlowExecution execution) {
+    }
+
+    /**
+     * All the registered {@link FlowExecutionListener}s.
+     */
+    public static ExtensionList<FlowExecutionListener> all() {
+        return ExtensionList.lookup(FlowExecutionListener.class);
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
@@ -26,8 +26,6 @@ public abstract class FlowExecutionListener implements ExtensionPoint {
     /**
      * Called when a {@link FlowExecution} has resumed.
      *
-     * The {@link FlowExecution} will already have been added to the {@link FlowExecutionList} by this point.
-     *
      * @param execution The {@link FlowExecution} that has resumed.
      */
     public void onResumed(FlowExecution execution) {
@@ -38,8 +36,8 @@ public abstract class FlowExecutionListener implements ExtensionPoint {
      *
      * The {@link FlowExecution} will already have been removed from the {@link FlowExecutionList} by this point,
      * {@link GraphListener.Synchronous#onNewHead(FlowNode)} will have already been called for the {@link FlowEndNode},
-     * {@link FlowEndNode#getResult()} will return non-null, and if the Pipeline has failed,
-     * {@link FlowExecution#getCauseOfFailure()} will return non-null.
+     * {@link FlowExecution#getCurrentHeads()} will have one element, a {@link FlowEndNode}, and if the Pipeline has
+     * failed, {@link FlowExecution#getCauseOfFailure()} will return non-null.
      *
      * @param execution The {@link FlowExecution} that has completed.
      */

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
@@ -49,7 +49,7 @@ public abstract class FlowExecutionListener implements ExtensionPoint {
     /**
      * Fires the {@link #onRunning(FlowExecution)} event.
      */
-    public static void fireRunning(FlowExecution execution) {
+    public static void fireRunning(@Nonnull FlowExecution execution) {
         for (FlowExecutionListener listener : ExtensionList.lookup(FlowExecutionListener.class)) {
             listener.onRunning(execution);
         }
@@ -58,7 +58,7 @@ public abstract class FlowExecutionListener implements ExtensionPoint {
     /**
      * Fires the {@link #onResumed(FlowExecution)} event.
      */
-    public static void fireResumed(FlowExecution execution) {
+    public static void fireResumed(@Nonnull FlowExecution execution) {
         for (FlowExecutionListener listener : ExtensionList.lookup(FlowExecutionListener.class)) {
             listener.onResumed(execution);
         }
@@ -67,7 +67,7 @@ public abstract class FlowExecutionListener implements ExtensionPoint {
     /**
      * Fires the {@link #onCompleted(FlowExecution)} event.
      */
-    public static void fireCompleted(FlowExecution execution) {
+    public static void fireCompleted(@Nonnull FlowExecution execution) {
         for (FlowExecutionListener listener : ExtensionList.lookup(FlowExecutionListener.class)) {
             listener.onCompleted(execution);
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.workflow.flow;
 
+import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 
 /**
@@ -27,4 +28,21 @@ public abstract class FlowExecutionListener implements ExtensionPoint {
     public void onCompleted(FlowExecution execution) {
     }
 
+    /**
+     * Fires the {@link #onRunning(FlowExecution, boolean)} event.
+     */
+    public static void fireRunning(FlowExecution execution, boolean resumed) {
+        for (FlowExecutionListener listener : ExtensionList.lookup(FlowExecutionListener.class)) {
+            listener.onRunning(execution, resumed);
+        }
+    }
+
+    /**
+     * Fires the {@link #onCompleted(FlowExecution)} event.
+     */
+    public static void fireCompleted(FlowExecution execution) {
+        for (FlowExecutionListener listener : ExtensionList.lookup(FlowExecutionListener.class)) {
+            listener.onCompleted(execution);
+        }
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
@@ -5,6 +5,8 @@ import hudson.ExtensionPoint;
 import org.jenkinsci.plugins.workflow.graph.FlowEndNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
+import javax.annotation.Nonnull;
+
 /**
  * Listens for significant status updates for a {@link FlowExecution}, such as started running or completed.
  *
@@ -20,7 +22,7 @@ public abstract class FlowExecutionListener implements ExtensionPoint {
      *
      * @param execution The {@link FlowExecution} that has started running.
      */
-    public void onRunning(FlowExecution execution) {
+    public void onRunning(@Nonnull FlowExecution execution) {
     }
 
     /**
@@ -28,7 +30,7 @@ public abstract class FlowExecutionListener implements ExtensionPoint {
      *
      * @param execution The {@link FlowExecution} that has resumed.
      */
-    public void onResumed(FlowExecution execution) {
+    public void onResumed(@Nonnull FlowExecution execution) {
     }
 
     /**
@@ -41,7 +43,7 @@ public abstract class FlowExecutionListener implements ExtensionPoint {
      *
      * @param execution The {@link FlowExecution} that has completed.
      */
-    public void onCompleted(FlowExecution execution) {
+    public void onCompleted(@Nonnull FlowExecution execution) {
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
@@ -2,6 +2,8 @@ package org.jenkinsci.plugins.workflow.flow;
 
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
+import org.jenkinsci.plugins.workflow.graph.FlowEndNode;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
 /**
  * Listens for significant status updates for a {@link FlowExecution}, such as started running or completed.
@@ -12,16 +14,32 @@ import hudson.ExtensionPoint;
 public abstract class FlowExecutionListener implements ExtensionPoint {
 
     /**
-     * Called when a {@link FlowExecution} has started running or resumed.
+     * Called when a {@link FlowExecution} has started running.
      *
-     * @param execution The {@link FlowExecution} that has started running or resumed.
-     * @param resumed True the execution is resuming, false if it's starting for the first time.
+     * The {@link FlowExecution} will already have been added to the {@link FlowExecutionList} by this point.
+     *
+     * @param execution The {@link FlowExecution} that has started running.
      */
-    public void onRunning(FlowExecution execution, boolean resumed) {
+    public void onRunning(FlowExecution execution) {
+    }
+
+    /**
+     * Called when a {@link FlowExecution} has resumed.
+     *
+     * The {@link FlowExecution} will already have been added to the {@link FlowExecutionList} by this point.
+     *
+     * @param execution The {@link FlowExecution} that has resumed.
+     */
+    public void onResumed(FlowExecution execution) {
     }
 
     /**
      * Called when a {@link FlowExecution} has completed.
+     *
+     * The {@link FlowExecution} will already have been removed from the {@link FlowExecutionList} by this point,
+     * {@link GraphListener.Synchronous#onNewHead(FlowNode)} will have already been called for the {@link FlowEndNode},
+     * {@link FlowEndNode#getResult()} will return non-null, and if the Pipeline has failed,
+     * {@link FlowExecution#getCauseOfFailure()} will return non-null.
      *
      * @param execution The {@link FlowExecution} that has completed.
      */
@@ -29,11 +47,20 @@ public abstract class FlowExecutionListener implements ExtensionPoint {
     }
 
     /**
-     * Fires the {@link #onRunning(FlowExecution, boolean)} event.
+     * Fires the {@link #onRunning(FlowExecution)} event.
      */
-    public static void fireRunning(FlowExecution execution, boolean resumed) {
+    public static void fireRunning(FlowExecution execution) {
         for (FlowExecutionListener listener : ExtensionList.lookup(FlowExecutionListener.class)) {
-            listener.onRunning(execution, resumed);
+            listener.onRunning(execution);
+        }
+    }
+
+    /**
+     * Fires the {@link #onResumed(FlowExecution)} event.
+     */
+    public static void fireResumed(FlowExecution execution) {
+        for (FlowExecutionListener listener : ExtensionList.lookup(FlowExecutionListener.class)) {
+            listener.onResumed(execution);
         }
     }
 


### PR DESCRIPTION
[JENKINS-43055](https://issues.jenkins-ci.org/browse/JENKINS-43055)

First attempt at JENKINS-43055, adding a `FlowExecutionListener` extension point that listens for started/paused/completed.

cc @reviewbybees 