### PR TITLE
Switch to POM properties for Pipeline-related dep versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,17 +65,26 @@
         <jenkins.version>1.642.3</jenkins.version>
         <no-test-jar>false</no-test-jar>
         <workflow-support-plugin.version>2.13</workflow-support-plugin.version>
+        <workflow-step-api.version>2.10</workflow-step-api.version>
+        <scm-api.version>1.3</scm-api.version>
+        <workflow-job.version>2.9</workflow-job.version>
+        <workflow-cps.version>2.27</workflow-cps.version>
+        <workflow-basic-steps.version>2.3</workflow-basic-steps.version>
+        <workflow-scm-step.version>2.3</workflow-scm-step.version>
+        <workflow-durable-task-step.version>2.8</workflow-durable-task-step.version>
+        <script-security.version>1.25</script-security.version>
+        <pipeline-stage-step.version>2.2</pipeline-stage-step.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.10</version>
+            <version>${workflow-step-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>1.3</version>
+            <version>${scm-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -86,19 +95,19 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.9</version>
+            <version>${workflow-job.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.27</version>
+            <version>${workflow-cps.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.3</version>
+            <version>${workflow-basic-steps.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>  <!-- For Semaphore step -->
@@ -111,25 +120,25 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.3</version>
+            <version>${workflow-scm-step.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.8</version>
+            <version>${workflow-durable-task-step.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.25</version>
+            <version>${script-security.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-stage-step</artifactId>
-            <version>2.2</version>
+            <version>${pipeline-stage-step.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
I'm working on tooling to do testing of core + groovy-sandbox +
groovy-cps + workflow-cps + script-security + the rest of the main
Pipeline plugins against bleeding-edge versions of each other and
different versions of Groovy. To do this, it'd be a lot easier if the
dependencies between the various things I'm building/testing had their
versions controlled by properties.

cc @reviewbybees 