### PR TITLE
[JENKINS-27395] Start recording enclosing blocks for flow nodes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/AtomNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/AtomNode.java
@@ -36,5 +36,6 @@ import org.jenkinsci.plugins.workflow.steps.Step;
 public abstract class AtomNode extends FlowNode {
     protected AtomNode(FlowExecution exec, String id, FlowNode... parents) {
         super(exec, id, parents);
+        this.enclosingId = findEnclosingId();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/BlockEndNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/BlockEndNode.java
@@ -44,12 +44,14 @@ public abstract class BlockEndNode<START extends BlockStartNode> extends FlowNod
         super(exec, id, parents);
         this.start = start;
         startId = start.getId();
+        this.enclosingId = findEnclosingId();
     }
 
     public BlockEndNode(FlowExecution exec, String id, START start, List<FlowNode> parents) {
         super(exec, id, parents);
         this.start = start;
         startId = start.getId();
+        this.enclosingId = findEnclosingId();
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/BlockStartNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/BlockStartNode.java
@@ -39,10 +39,12 @@ import java.util.List;
 public abstract class BlockStartNode extends FlowNode {
     protected BlockStartNode(FlowExecution exec, String id, FlowNode... parents) {
         super(exec, id, parents);
+        this.enclosingId = findEnclosingId();
     }
 
     protected BlockStartNode(FlowExecution exec, String id, List<FlowNode> parents) {
         super(exec, id, parents);
+        this.enclosingId = findEnclosingId();
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/graph/FlowNodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/graph/FlowNodeTest.java
@@ -29,12 +29,15 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
+
 import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.runners.model.Statement;
@@ -121,4 +124,251 @@ public class FlowNodeTest {
         assertEquals(Arrays.asList(expected), actual);
     }
 
+    @Issue("JENKINS-27395")
+    @Test
+    public void enclosingBlocks() throws Exception {
+        rr.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                WorkflowJob job = rr.j.createProject(WorkflowJob.class, "enclosingBlocks");
+                /*
+                Node dump follows, format:
+[ID]{parent,ids}(millisSinceStartOfRun) flowNodeClassName stepDisplayName [st=startId if a block end node]
+Action format:
+	- actionClassName actionDisplayName
+------------------------------------------------------------------------------------------
+[2]{}FlowStartNode Start of Pipeline
+[3]{2}StepStartNode Stage : Start
+  -LogActionImpl Console Output
+  -ArgumentsActionImpl null
+[4]{3}StepStartNode outermost
+  -BodyInvocationAction null
+  -LabelAction outermost
+[5]{4}StepAtomNode Print Message
+  -LogActionImpl Console Output
+  -ArgumentsActionImpl null
+[6]{5}StepStartNode Execute in parallel : Start
+  -LogActionImpl Console Output
+[8]{6}StepStartNode Branch: a
+  -BodyInvocationAction null
+  -ParallelLabelAction Branch: a
+[9]{6}StepStartNode Branch: b
+  -BodyInvocationAction null
+  -ParallelLabelAction Branch: b
+[10]{8}StepStartNode Stage : Start
+  -LogActionImpl Console Output
+  -ArgumentsActionImpl null
+[11]{10}StepStartNode inner-a
+  -BodyInvocationAction null
+  -LabelAction inner-a
+[12]{9}StepStartNode Stage : Start
+  -LogActionImpl Console Output
+  -ArgumentsActionImpl null
+[13]{12}StepStartNode inner-b
+  -BodyInvocationAction null
+  -LabelAction inner-b
+[14]{11}StepAtomNode Print Message
+  -LogActionImpl Console Output
+  -ArgumentsActionImpl null
+[15]{14}StepStartNode Stage : Start
+  -LogActionImpl Console Output
+  -ArgumentsActionImpl null
+[16]{15}StepStartNode innermost-a
+  -BodyInvocationAction null
+  -LabelAction innermost-a
+[17]{13}StepAtomNode Print Message
+  -LogActionImpl Console Output
+  -ArgumentsActionImpl null
+[18]{17}StepStartNode Stage : Start
+  -LogActionImpl Console Output
+  -ArgumentsActionImpl null
+[19]{18}StepStartNode innermost-b
+  -BodyInvocationAction null
+  -LabelAction innermost-b
+[20]{16}StepAtomNode Print Message
+  -LogActionImpl Console Output
+  -ArgumentsActionImpl null
+[21]{20}StepEndNode Stage : Body : End  [st=16]
+  -BodyInvocationAction null
+[22]{19}StepAtomNode Print Message
+  -LogActionImpl Console Output
+  -ArgumentsActionImpl null
+[23]{22}StepEndNode Stage : Body : End  [st=19]
+  -BodyInvocationAction null
+[24]{21}StepEndNode Stage : End  [st=15]
+[25]{23}StepEndNode Stage : End  [st=18]
+[26]{24}StepEndNode Stage : Body : End  [st=11]
+  -BodyInvocationAction null
+[27]{25}StepEndNode Stage : Body : End  [st=13]
+  -BodyInvocationAction null
+[28]{26}StepEndNode Stage : End  [st=10]
+[29]{27}StepEndNode Stage : End  [st=12]
+[30]{28}StepEndNode Execute in parallel : Body : End  [st=8]
+  -BodyInvocationAction null
+[31]{29}StepEndNode Execute in parallel : Body : End  [st=9]
+  -BodyInvocationAction null
+[32]{30,31}StepEndNode Execute in parallel : End  [st=6]
+[33]{32}StepEndNode Stage : Body : End  [st=4]
+  -BodyInvocationAction null
+[34]{33}StepEndNode Stage : End  [st=3]
+[35]{34}FlowEndNode End of Pipeline  [st=2]
+------------------------------------------------------------------------------------------
+                 */
+                job.setDefinition(new CpsFlowDefinition(
+                        "stage('outermost') {\n" +
+                                "  echo 'in outermost'\n" +
+                                "  parallel(a: {\n" +
+                                "    stage('inner-a') {\n" +
+                                "      echo 'in inner-a'\n" +
+                                "      stage('innermost-a') {\n" +
+                                "        echo 'in innermost-a'\n" +
+                                "      }\n" +
+                                "    }\n" +
+                                "  },\n" +
+                                "  b: {\n" +
+                                "    stage('inner-b') {\n" +
+                                "      echo 'in inner-b'\n" +
+                                "      stage('innermost-b') {\n" +
+                                "        echo 'in innermost-b'\n" +
+                                "      }\n" +
+                                "    }\n" +
+                                "  })\n" +
+                                "}\n", true));
+
+                WorkflowRun r = rr.j.buildAndAssertSuccess(job);
+
+                FlowExecution execution = r.getExecution();
+
+                // FlowStartNode
+                assertExpectedEnclosing(execution, "2", null);
+
+                // outermost stage start
+                assertExpectedEnclosing(execution, "3", null);
+
+                // outermost stage body
+                assertExpectedEnclosing(execution, "4", "3");
+
+                // outermost echo
+                assertExpectedEnclosing(execution, "5", "4");
+
+                // parallel start
+                assertExpectedEnclosing(execution, "6", "4");
+
+                // Branch a start
+                assertExpectedEnclosing(execution, "8", "6");
+
+                // Branch b start
+                assertExpectedEnclosing(execution, "9", "6");
+
+                // Stage inner-a start
+                assertExpectedEnclosing(execution, "10", "8");
+
+                // Stage inner-a body
+                assertExpectedEnclosing(execution, "11", "10");
+
+                // Stage inner-b start
+                assertExpectedEnclosing(execution, "12", "9");
+
+                // Stage inner-b body
+                assertExpectedEnclosing(execution, "13", "12");
+
+                // echo inner-a
+                assertExpectedEnclosing(execution, "14", "11");
+
+                // Stage innermost-a start
+                assertExpectedEnclosing(execution, "15", "11");
+
+                // Stage innermost-a body
+                assertExpectedEnclosing(execution, "16", "15");
+
+                // echo inner-b
+                assertExpectedEnclosing(execution, "17", "13");
+
+                // Stage innermost-b start
+                assertExpectedEnclosing(execution, "18", "13");
+
+                // Stage innermost-b body
+                assertExpectedEnclosing(execution, "19", "18");
+
+                // echo innermost-a
+                assertExpectedEnclosing(execution, "20", "16");
+
+                // Stage innermost-a body end
+                assertExpectedEnclosing(execution, "21", "15");
+
+                // echo innermost-b
+                assertExpectedEnclosing(execution, "22", "19");
+
+                // Stage innermost-b body end
+                assertExpectedEnclosing(execution, "23", "18");
+
+                // Stage innermost-a end
+                assertExpectedEnclosing(execution, "24", "11");
+
+                // Stage innermost-b end
+                assertExpectedEnclosing(execution, "25", "13");
+
+                // Stage inner-a body end
+                assertExpectedEnclosing(execution, "26", "10");
+
+                // Stage inner-b body end
+                assertExpectedEnclosing(execution, "27", "12");
+
+                // Stage inner-a end
+                assertExpectedEnclosing(execution, "28", "8");
+
+                // Stage inner-b end
+                assertExpectedEnclosing(execution, "29", "9");
+
+                // Branch a end
+                assertExpectedEnclosing(execution, "30", "6");
+
+                // Branch b end
+                assertExpectedEnclosing(execution, "31", "6");
+
+                // parallel end
+                assertExpectedEnclosing(execution, "32", "4");
+
+                // outermost stage body end
+                assertExpectedEnclosing(execution, "33", "3");
+
+                // outermost stage end
+                assertExpectedEnclosing(execution, "34", null);
+
+                // FlowEndNode
+                assertExpectedEnclosing(execution, "35", null);
+            }
+        });
+    }
+
+    private void assertExpectedEnclosing(FlowExecution execution, String nodeId, String enclosingId) throws Exception {
+        FlowNode node = execution.getNode(nodeId);
+        assertNotNull(node);
+
+        assertEquals(enclosingId, node.getEnclosingId());
+        if (enclosingId == null) {
+            assertTrue(node.getAllEnclosingIds().isEmpty());
+            assertTrue(node.getEnclosingBlocks().isEmpty());
+        } else {
+            FlowNode enclosingNode = execution.getNode(enclosingId);
+            assertNotNull(enclosingNode);
+            assertEquals(enclosingIdsIncludingNode(enclosingNode), node.getAllEnclosingIds());
+            assertEquals(enclosingBlocksIncludingNode(enclosingNode), node.getEnclosingBlocks());
+        }
+    }
+
+    private List<String> enclosingIdsIncludingNode(FlowNode node) {
+        List<String> encl = new ArrayList<>();
+        encl.add(node.getId());
+        encl.addAll(node.getAllEnclosingIds());
+        return encl;
+    }
+
+    private List<FlowNode> enclosingBlocksIncludingNode(FlowNode node) {
+        List<FlowNode> encl = new ArrayList<>();
+        encl.add(node);
+        encl.addAll(node.getEnclosingBlocks());
+        return encl;
+    }
 }
+


### PR DESCRIPTION
[JENKINS-27395](https://issues.jenkins-ci.org/browse/JENKINS-27395)

Specifically for AtomNodes, BlockStartNodes, and BlockEndNodes.

Will be upstream of https://github.com/jenkinsci/junit-plugin/pull/76 shortly.

cc @reviewbybees 