### PR TITLE
Provide FlowNode APIs to let us be more selective about when we persist data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-api</artifactId>
-    <version>2.21-SNAPSHOT</version>
+    <version>2.21-deferactionwrite-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: API</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+API+Plugin</url>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.10</version>
+            <version>2.13-deferactionwrite-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,10 @@
     </properties>
     <dependencies>
         <dependency>
+            <!-- Temp version until https://github.com/jenkinsci/workflow-step-api-plugin/pull/29 gets released  -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.13-deferactionwrite-SNAPSHOT</version>
+            <version>2.13-deferactionwrite2-20170901.210414-1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/TimingAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/TimingAction.java
@@ -31,7 +31,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
  *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class TimingAction implements Action {
+public class TimingAction implements PersistentAction {
 
     // TODO perhaps add a FlowNodeViewColumn rendering <i:formatDate value="…" type="both" dateStyle="medium" timeStyle="medium"/>
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -466,7 +466,7 @@ public abstract class FlowNode extends Actionable implements Saveable {
     }
 
     /** Add an action without forcing persistence of the FlowNode and its actions */
-    public void addActionWithoutPersist(PersistentAction action) {
+    public void addActionWithoutPersist(Action action) {
         loadActions();
         this.actions.add(action);
     }
@@ -533,7 +533,7 @@ public abstract class FlowNode extends Actionable implements Saveable {
     }
 
     // Persist, handling possible IOException
-    private void persistSafe() {
+    public void persistSafe() {
         try {
             save();
         } catch (IOException e) {


### PR DESCRIPTION
Upstream of major performance optimization to FlowNode storage that significantly decreases persistence calls.

This lets us:
- [x] Signal if a FlowNode shouldn't be directly persisted with every new action added
- [x] Attach actions to a FlowNode explicitly without triggering disk persistence
- [x] Trigger explicit serialization of FlowNodes

More detail TBD when I finish filling in all the administrivia and file appropriate JIRAs.

- Although doesn't directly consume API from https://github.com/jenkinsci/workflow-step-api-plugin/pull/29 we need to ensure that both APIs are present in all plugins consuming this version, so we add a dependency

Snapshot deployed:

```
<dependency>
            <groupId>org.jenkins-ci.plugins.workflow</groupId>
            <artifactId>workflow-api</artifactId>
            <!-- Temp version for https://github.com/jenkinsci/workflow-api-plugin/pull/49 -->
            <version>2.21-deferactionwrite-20170901.212705-1</version>
        </dependency>
```

Note:

- Test coverage is via the FlowNodeStorage impls in Workflow-support plugin (downstream)