### PR TITLE
Be more defensive about errors in FlowExecutionList.load

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -98,8 +98,8 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
             try {
                 runningTasks.replaceBy((List<FlowExecutionOwner>) cf.read());
                 LOGGER.log(FINE, "loaded: {0}", runningTasks);
-            } catch (IOException x) {
-                LOGGER.log(WARNING, null, x);
+            } catch (Exception x) {
+                LOGGER.log(WARNING, "ignoring broken " + cf, x);
             }
         }
     }


### PR DESCRIPTION
A user with a totally malformed `org.jenkinsci.plugins.workflow.flow.FlowExecutionList.xml` reported a complete inability to run new builds:

```
java.lang.ClassCastException: … cannot be cast to java.util.List
	at org.jenkinsci.plugins.workflow.flow.FlowExecutionList.load(FlowExecutionList.java:99)
	at org.jenkinsci.plugins.workflow.flow.FlowExecutionList.<init>(FlowExecutionList.java:49)
	at org.jenkinsci.plugins.workflow.flow.FlowExecutionList.get(FlowExecutionList.java:162)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:248)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:404)
```

Regardless of the root cause, it is best to recover more gracefully.

@reviewbybees