### PR TITLE
getEnclosingBlocks should return a List<? extends BlockStartNode>, not a List<FlowNode>

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -24,15 +24,8 @@
 
 package org.jenkinsci.plugins.workflow.graph;
 
-import com.google.common.base.Predicates;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.Extension;
-import hudson.ExtensionList;
 import hudson.model.Action;
 import hudson.model.Actionable;
 import hudson.model.BallColor;
@@ -43,13 +36,9 @@ import java.io.ObjectStreamException;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
@@ -59,11 +48,6 @@ import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.PersistentAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
-import org.jenkinsci.plugins.workflow.flow.FlowExecutionListener;
-import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
-import org.jenkinsci.plugins.workflow.flow.GraphListener;
-import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
-import org.jenkinsci.plugins.workflow.graphanalysis.LinearBlockHoppingScanner;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -203,8 +187,8 @@ public abstract class FlowNode extends Actionable implements Saveable {
      * May be empty if we are the {@link FlowStartNode} or {@link FlowEndNode}
      */
     @Nonnull
-    public List<FlowNode> getEnclosingBlocks() {
-        return (List)this.exec.findAllEnclosingBlockStarts(this);
+    public List<? extends BlockStartNode> getEnclosingBlocks() {
+        return this.exec.findAllEnclosingBlockStarts(this);
     }
 
     /** Return an iterator over all enclosing blocks.
@@ -219,7 +203,7 @@ public abstract class FlowNode extends Actionable implements Saveable {
      */
     @Nonnull
     public List<String> getAllEnclosingIds() {
-        List<FlowNode> nodes = getEnclosingBlocks();
+        List<? extends BlockStartNode> nodes = getEnclosingBlocks();
         ArrayList<String> output = new ArrayList<String>(nodes.size());
         for (FlowNode f : nodes) {
             output.add(f.getId());


### PR DESCRIPTION
Silly to use an unchecked cast to widen the return type, when the method’s very Javadoc is explicit that it will return `BlockStartNode`s specifically.

Also using a wildcard to emphasize that the result is read-only.

Not necessarily source-compatible, but is binary-compatible.

@reviewbybees