### PR TITLE
Slightly reduce memory used by ArgumentsAction.getFilteredArguments()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ArgumentsAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ArgumentsAction.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.actions;
 
+import com.google.common.collect.Maps;
 import com.google.common.primitives.Primitives;
 import hudson.PluginManager;
 import hudson.model.Describable;
@@ -162,7 +163,7 @@ public abstract class ArgumentsAction implements PersistentAction {
         if (internalArgs.size() == 0) {
             return Collections.<String,Object>emptyMap();
         }
-        HashMap<String, Object> filteredArguments = new HashMap<String, Object>();
+        HashMap<String, Object> filteredArguments = Maps.newHashMapWithExpectedSize(internalArgs.size());
         for (Map.Entry<String, Object> entry : internalArgs.entrySet()) {
             if (entry.getValue() != null && !(entry.getValue() instanceof NotStoredReason)) {
                 // TODO this is incorrect: value could be a Map/List with some nested entries that are NotStoredReason


### PR DESCRIPTION
Pre-sizes the Hashmap correctly, reducing the amount of garbage generated - this method will get called often for UI display of Step arguments, so it's probably worthwhile to do this.

@reviewbybees 