### PR TITLE
MessageFormat treats ' as a special character  …

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/flow/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/flow/Messages.properties
@@ -1,5 +1,5 @@
 FlowDurabilityHint.PERFORMANCE_OPTIMIZED.description=Performance-optimized: much faster (requires clean shutdown to save running pipelines)
-FlowDurabilityHint.PERFORMANCE_OPTIMIZED.tooltip=Avoids writing data with every step, avoids atomic writes of data.  Pipelines can resume if Jenkins shuts down cleanly, but running pipelines lose step information and can't resume if Jenkins unexpectedly fails.
+FlowDurabilityHint.PERFORMANCE_OPTIMIZED.tooltip=Avoids writing data with every step, avoids atomic writes of data.  Pipelines can resume if Jenkins shuts down cleanly, but running pipelines lose step information and cannot resume if Jenkins unexpectedly fails.
 FlowDurabilityHint.SURVIVABLE_NONATOMIC.description=Less durability, a bit faster (specialty use only)
 FlowDurabilityHint.SURVIVABLE_NONATOMIC.tooltip=Writes data with every step but avoids atomic writes. On some filesytems this is faster than maximum durability mode, but running pipeline data may be lost if disk writes are interrupted or fail.
 FlowDurabilityHint.MAX_SURVIVABILITY.description=Maximum durability but slowest (previously the only option)


### PR DESCRIPTION
 https://docs.oracle.com/javase/8/docs/api/java/text/MessageFormat.html

Test case is jenkins/configure
 Expand "Pipeline Default Speed/Durability Level"
 Help for "Performance-optimized: much faster (requires clean shutdown to save running pipelines)"

Without this fix, you will see:
... but running pipelines lose step information and cant resume if Jenkins unexpectedly fails.

You should see:
... but running pipelines lose step information and can't resume if Jenkins unexpectedly fails.

This is equivalent to jenkinsci/jenkins#3203 but for this repo...