### PR TITLE
avoid printing too long argument lists during FlowNode visualization

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ArgumentsAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ArgumentsAction.java
@@ -39,6 +39,7 @@ import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -197,7 +198,7 @@ public abstract class ArgumentsAction implements PersistentAction {
             StepDescriptor descriptor = ((StepNode) n).getDescriptor();
             if (descriptor != null) {  // Null if plugin providing descriptor was uninstalled
                 Map<String, Object> filteredArgs = getFilteredArguments(n);
-                return descriptor.argumentsToString(filteredArgs);
+                return StringUtils.substring(descriptor.argumentsToString(filteredArgs), 0, 80);
             }
         }
         return null;  // non-StepNode nodes can't have step arguments

--- a/src/test/java/org/jenkinsci/plugins/workflow/graph/FlowNodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/graph/FlowNodeTest.java
@@ -450,5 +450,33 @@ Action format:
         encl.addAll(node.getEnclosingBlocks());
         return encl;
     }
-}
 
+    @Test
+    public void testLongStepArguments() throws Exception {
+        rr.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                WorkflowJob job = rr.j.createProject(WorkflowJob.class, "testLongStepArguments");
+
+                job.setDefinition(new CpsFlowDefinition(
+                    "node('master') {\n" +
+                    "    stage('weird') {\n" +
+                    "        echo 'lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so,lib01.so'\n" +
+                    "    }\n" +
+                    "}\n")
+                );
+                WorkflowRun r = rr.j.buildAndAssertSuccess(job);
+
+                FlowExecution execution = r.getExecution();
+
+                DepthFirstScanner scan = new DepthFirstScanner();
+                for (FlowNode n : scan.allNodes(execution)) {
+                    String args = ArgumentsAction.getStepArgumentsAsString(n);
+                    if(args!=null) {
+                        assertTrue(args.length() <= 80);
+                    }
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
In some cases it is possible that node argument will be impossible to
wrap properly and is displayed as single line. In this case pipeline
steps view becomes hard to read because right most columns are moved
beyond the screen. this requires scrolling which is not so convenient.
Also status colum is outside of screen.

This change cuts arguments list to 80 characters which should be fine
for most of usages.

Signed-off-by: Artur Harasimiuk <artur.harasimiuk@intel.com>