### PR TITLE
use ABORTED icon color for interrupted steps

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -51,6 +51,7 @@ import org.jenkinsci.plugins.workflow.actions.PersistentAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graphanalysis.FlowScanningUtils;
 import org.jenkinsci.plugins.workflow.graphanalysis.NodeStepTypePredicate;
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -279,7 +280,17 @@ public abstract class FlowNode extends Actionable implements Saveable {
      */
     @Exported
     public BallColor getIconColor() {
-        BallColor c = getError()!=null ? BallColor.RED : BallColor.BLUE;
+        ErrorAction error = getError();
+        BallColor c = null;
+        if(error != null) {
+            if(error.getError() instanceof FlowInterruptedException) {
+                c = BallColor.ABORTED;
+            } else {
+                c = BallColor.RED;
+            }
+        } else {
+            c = BallColor.BLUE;
+        }
         if (isActive()) {
             c = c.anime();
         }


### PR DESCRIPTION
parallel() aborts branch execution when failFast == true and another
branch failed. In this case RED color is used in 'Pipeline Steps' view.
It makes more difficult to find real reason of failure because some of
red dots are misleading.

With this change we use BallColor.ABORTED when FlowInterruptedException
is the reason of step failure. Thanks to this user can easier find root
cause of build failure.

Signed-off-by: Artur Harasimiuk <artur.harasimiuk@intel.com>