### PR TITLE
Comment & annotation fix

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/log/TaskListenerDecorator.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/TaskListenerDecorator.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import jenkins.util.BuildListenerAdapter;
 import jenkins.util.JenkinsJVM;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
@@ -87,7 +88,7 @@ public abstract class TaskListenerDecorator implements /* TODO Remotable */ Seri
      * @param subsequent an overriding decorator, if any
      * @return null, or {@code original} or {@code subsequent}, or a merged result applying one then the other
      */
-    public static @CheckForNull TaskListenerDecorator merge(@CheckForNull TaskListenerDecorator original, @CheckForNull TaskListenerDecorator subsequent) {
+    public static @Nullable TaskListenerDecorator merge(@CheckForNull TaskListenerDecorator original, @CheckForNull TaskListenerDecorator subsequent) {
         if (original == null) {
             if (subsequent == null) {
                 return null;

--- a/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
@@ -38,7 +38,6 @@ import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.function.BiFunction;
 import java.util.logging.Logger;
-import jenkins.security.ConfidentialStore;
 import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
@@ -60,7 +59,6 @@ public abstract class LogStorageTestBase {
         System.setProperty("line.separator", "\n");
     }
 
-    /** Needed since {@link ConsoleAnnotators} will not work without encryption, and currently {@link ConfidentialStore#get} has no fallback mode for unit tests accessible except via package-local. */
     @ClassRule public static JenkinsRule r = new JenkinsRule();
 
     /** Create a new storage implementation, but potentially reusing any data initialized in the last {@link Before} setup. */


### PR DESCRIPTION
A bit of JEP-210 cleanup. The `JenkinsRule` is being used explicitly in `remoting`, so this comment was just misleading. Also fixing a nullability annotation from #76.