### PR TITLE
[JENKINS-54073] Buffering for FileLogStorage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.21</version>
+        <version>3.25</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -64,22 +64,22 @@
     <properties>
         <revision>2.31</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.121</jenkins.version>
+        <jenkins.version>2.121.1</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
-        <workflow-support-plugin.version>2.14</workflow-support-plugin.version>
+        <workflow-support-plugin.version>2.21</workflow-support-plugin.version>
         <useBeta>true</useBeta>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.10</version>
+            <version>2.16</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>2.0.8</version>
+            <version>2.2.6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -90,13 +90,13 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.11.1</version>
+            <version>2.26</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.33</version>
+            <version>2.58</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -121,13 +121,13 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.8</version>
+            <version>2.22</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.27</version>
+            <version>1.46</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.14</version>
+            <version>1.17</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.test</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/BufferedBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/BufferedBuildListener.java
@@ -67,13 +67,14 @@ final class BufferedBuildListener implements BuildListener, Closeable, Serializa
         private static final long serialVersionUID = 1;
 
         private final RemoteOutputStream ros;
+        private final DelayBufferedOutputStream.Tuning tuning = DelayBufferedOutputStream.Tuning.DEFAULT; // load defaults on master
 
         Replacement(BufferedBuildListener cbl) {
             this.ros = new RemoteOutputStream(new CloseProofOutputStream(cbl.out));
         }
 
         private Object readResolve() throws IOException {
-            return new BufferedBuildListener(new DelayBufferedOutputStream(ros));
+            return new BufferedBuildListener(new DelayBufferedOutputStream(ros, tuning));
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/BufferedBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/BufferedBuildListener.java
@@ -1,0 +1,176 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.log;
+
+import hudson.model.BuildListener;
+import hudson.remoting.RemoteOutputStream;
+import hudson.util.StreamTaskListener;
+import java.io.BufferedOutputStream;
+import java.io.Closeable;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jenkins.util.Timer;
+import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
+
+/**
+ * Unlike {@link StreamTaskListener} this does not set {@code autoflush} on the reconstructed {@link PrintStream}.
+ * It also implements buffering on output, flushed (without ProxyOutputStream.Flush) at intervals.
+ */
+final class BufferedBuildListener implements BuildListener, Closeable, SerializableOnlyOverRemoting {
+
+    private static final Logger LOGGER = Logger.getLogger(BufferedBuildListener.class.getName());
+
+    private final OutputStream out;
+    private final PrintStream ps;
+
+    BufferedBuildListener(OutputStream out) throws IOException {
+        this.out = out;
+        ps = new PrintStream(out, false, "UTF-8");
+    }
+    
+    @Override public PrintStream getLogger() {
+        return ps;
+    }
+    
+    @Override public void close() throws IOException {
+        ps.close();
+    }
+
+    private Object writeReplace() {
+        return new Replacement(this);
+    }
+
+    private static final class Replacement implements SerializableOnlyOverRemoting {
+
+        private static final long serialVersionUID = 1;
+
+        private final RemoteOutputStream ros;
+
+        Replacement(BufferedBuildListener cbl) {
+            this.ros = new RemoteOutputStream(cbl.out);
+        }
+
+        private Object readResolve() throws IOException {
+            return new BufferedBuildListener(new DelayBufferedOutputStream(ros));
+        }
+
+    }
+
+    private static final class DelayBufferedOutputStream extends BufferedOutputStream {
+
+        // TODO make these customizable (not trivial since this system properties would need to be loaded on the master side and then remoted)
+        private static final long MIN_RECURRENCE_PERIOD = 250; // ¼s
+        private static final long MAX_RECURRENCE_PERIOD = 10_000; // 10s
+        private static final float RECURRENCE_PERIOD_BACKOFF = 1.05f;
+
+        private long recurrencePeriod = MIN_RECURRENCE_PERIOD;
+
+        DelayBufferedOutputStream(OutputStream out) {
+            super(new FlushProofOutputStream(out)); // default buffer size: 8Kib
+            reschedule();
+        }
+
+        private void reschedule() {
+            Timer.get().schedule(new Flush(this), recurrencePeriod, TimeUnit.MILLISECONDS);
+            recurrencePeriod = Math.min((long) (recurrencePeriod * RECURRENCE_PERIOD_BACKOFF), MAX_RECURRENCE_PERIOD);
+        }
+
+        /** We can only call {@link BufferedOutputStream#flushBuffer} via {@link #flush}, but we do not wish to flush the underlying stream, only write out the buffer. */
+        private void flushBuffer() throws IOException {
+            ThreadLocal<Boolean> fauxFlushing = ((FlushProofOutputStream) out).fauxFlushing;
+            boolean orig = fauxFlushing.get();
+            fauxFlushing.set(true);
+            try {
+                flush();
+            } finally {
+                fauxFlushing.set(orig);
+            }
+        }
+        
+        @Override public void close() throws IOException {
+            // Ignored. We do not allow the stream to be closed from the remote side.
+        }
+        
+        void run() {
+            try {
+                flushBuffer();
+            } catch (IOException x) {
+                LOGGER.log(Level.FINE, null, x);
+            }
+            reschedule();
+        }
+        
+    }
+    
+    private static final class Flush implements Runnable {
+
+        /** Since there is no explicit close event, just keep flushing periodically until the stream is collected. */
+        private final Reference<DelayBufferedOutputStream> osr;
+        
+        Flush(DelayBufferedOutputStream os) {
+            osr = new WeakReference<>(os);
+        }
+        
+        @Override public void run() {
+            DelayBufferedOutputStream os = osr.get();
+            if (os != null) {
+                os.run();
+            }
+        }
+        
+    }
+
+    private static final class FlushProofOutputStream extends FilterOutputStream {
+
+        private final ThreadLocal<Boolean> fauxFlushing = new ThreadLocal<Boolean>() {
+            @Override protected Boolean initialValue() {
+                return false;
+            }
+        };
+
+        FlushProofOutputStream(OutputStream out) {
+            super(out);
+        }
+
+        @Override public void write(byte[] b, int off, int len) throws IOException {
+            out.write(b, off, len); // super method writes one byte at a time!
+        }
+        
+        @Override public void flush() throws IOException {
+            if (!fauxFlushing.get()) {
+                super.flush();
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/BufferedBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/BufferedBuildListener.java
@@ -25,30 +25,21 @@
 package org.jenkinsci.plugins.workflow.log;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.CloseProofOutputStream;
 import hudson.model.BuildListener;
 import hudson.remoting.RemoteOutputStream;
 import hudson.util.StreamTaskListener;
-import java.io.BufferedOutputStream;
 import java.io.Closeable;
-import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.lang.ref.Reference;
-import java.lang.ref.WeakReference;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import jenkins.util.Timer;
 import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
 
 /**
  * Unlike {@link StreamTaskListener} this does not set {@code autoflush} on the reconstructed {@link PrintStream}.
- * It also implements buffering on output, flushed (without ProxyOutputStream.Flush) at intervals.
+ * It also wraps on the remote side in {@link DelayBufferedOutputStream}.
  */
 final class BufferedBuildListener implements BuildListener, Closeable, SerializableOnlyOverRemoting {
-
-    private static final Logger LOGGER = Logger.getLogger(BufferedBuildListener.class.getName());
 
     private final OutputStream out;
     @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "using Replacement anyway, fields here are irrelevant")
@@ -78,100 +69,11 @@ final class BufferedBuildListener implements BuildListener, Closeable, Serializa
         private final RemoteOutputStream ros;
 
         Replacement(BufferedBuildListener cbl) {
-            this.ros = new RemoteOutputStream(cbl.out);
+            this.ros = new RemoteOutputStream(new CloseProofOutputStream(cbl.out));
         }
 
         private Object readResolve() throws IOException {
             return new BufferedBuildListener(new DelayBufferedOutputStream(ros));
-        }
-
-    }
-
-    private static final class DelayBufferedOutputStream extends BufferedOutputStream {
-
-        // TODO make these customizable (not trivial since this system properties would need to be loaded on the master side and then remoted)
-        private static final long MIN_RECURRENCE_PERIOD = 250; // ¼s
-        private static final long MAX_RECURRENCE_PERIOD = 10_000; // 10s
-        private static final float RECURRENCE_PERIOD_BACKOFF = 1.05f;
-
-        private long recurrencePeriod = MIN_RECURRENCE_PERIOD;
-
-        DelayBufferedOutputStream(OutputStream out) {
-            super(new FlushControlledOutputStream(out)); // default buffer size: 8Kib
-            reschedule();
-        }
-
-        private void reschedule() {
-            Timer.get().schedule(new Flush(this), recurrencePeriod, TimeUnit.MILLISECONDS);
-            recurrencePeriod = Math.min((long) (recurrencePeriod * RECURRENCE_PERIOD_BACKOFF), MAX_RECURRENCE_PERIOD);
-        }
-
-        /** We can only call {@link BufferedOutputStream#flushBuffer} via {@link #flush}, but we do not wish to flush the underlying stream, only write out the buffer. */
-        private void flushBuffer() throws IOException {
-            ThreadLocal<Boolean> enableFlush = ((FlushControlledOutputStream) out).enableFlush;
-            boolean orig = enableFlush.get();
-            enableFlush.set(false);
-            try {
-                flush();
-            } finally {
-                enableFlush.set(orig);
-            }
-        }
-        
-        @Override public void close() throws IOException {
-            // Ignored. We do not allow the stream to be closed from the remote side.
-        }
-        
-        void run() {
-            try {
-                flushBuffer();
-            } catch (IOException x) {
-                LOGGER.log(Level.FINE, null, x);
-            }
-            reschedule();
-        }
-        
-    }
-    
-    private static final class Flush implements Runnable {
-
-        /** Since there is no explicit close event, just keep flushing periodically until the stream is collected. */
-        private final Reference<DelayBufferedOutputStream> osr;
-        
-        Flush(DelayBufferedOutputStream os) {
-            osr = new WeakReference<>(os);
-        }
-        
-        @Override public void run() {
-            DelayBufferedOutputStream os = osr.get();
-            if (os != null) {
-                os.run();
-            }
-        }
-        
-    }
-
-    /** @see DelayBufferedOutputStream#flushBuffer */
-    private static final class FlushControlledOutputStream extends FilterOutputStream {
-
-        private final ThreadLocal<Boolean> enableFlush = new ThreadLocal<Boolean>() {
-            @Override protected Boolean initialValue() {
-                return true;
-            }
-        };
-
-        FlushControlledOutputStream(OutputStream out) {
-            super(out);
-        }
-
-        @Override public void write(byte[] b, int off, int len) throws IOException {
-            out.write(b, off, len); // super method writes one byte at a time!
-        }
-        
-        @Override public void flush() throws IOException {
-            if (enableFlush.get()) {
-                super.flush();
-            }
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/BufferedBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/BufferedBuildListener.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.log;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.BuildListener;
 import hudson.remoting.RemoteOutputStream;
 import hudson.util.StreamTaskListener;
@@ -50,6 +51,7 @@ final class BufferedBuildListener implements BuildListener, Closeable, Serializa
     private static final Logger LOGGER = Logger.getLogger(BufferedBuildListener.class.getName());
 
     private final OutputStream out;
+    @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "using Replacement anyway, fields here are irrelevant")
     private final PrintStream ps;
 
     BufferedBuildListener(OutputStream out) throws IOException {

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/DelayBufferedOutputStream.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/DelayBufferedOutputStream.java
@@ -1,0 +1,127 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.log;
+
+import java.io.BufferedOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jenkins.util.Timer;
+
+/**
+ * Buffered output stream which is guaranteed to deliver content after some time even if idle and the buffer does not fill up.
+ * The automatic “flushing” does <em>not</em> flush the underlying stream, for example via {@code ProxyOutputStream.Flush}.
+ */
+final class DelayBufferedOutputStream extends BufferedOutputStream {
+
+    private static final Logger LOGGER = Logger.getLogger(DelayBufferedOutputStream.class.getName());
+
+    // TODO make these customizable (not trivial since this system properties would need to be loaded on the master side and then remoted)
+    private static final long MIN_RECURRENCE_PERIOD = 250; // ¼s
+    private static final long MAX_RECURRENCE_PERIOD = 10_000; // 10s
+    private static final float RECURRENCE_PERIOD_BACKOFF = 1.05f;
+
+    private long recurrencePeriod = MIN_RECURRENCE_PERIOD;
+
+    DelayBufferedOutputStream(OutputStream out) {
+        super(new FlushControlledOutputStream(out)); // default buffer size: 8Kib
+        reschedule();
+    }
+
+    private void reschedule() {
+        Timer.get().schedule(new Flush(this), recurrencePeriod, TimeUnit.MILLISECONDS);
+        recurrencePeriod = Math.min((long) (recurrencePeriod * RECURRENCE_PERIOD_BACKOFF), MAX_RECURRENCE_PERIOD);
+    }
+
+    /** We can only call {@link BufferedOutputStream#flushBuffer} via {@link #flush}, but we do not wish to flush the underlying stream, only write out the buffer. */
+    private void flushBuffer() throws IOException {
+        ThreadLocal<Boolean> enableFlush = ((FlushControlledOutputStream) out).enableFlush;
+        boolean orig = enableFlush.get();
+        enableFlush.set(false);
+        try {
+            flush();
+        } finally {
+            enableFlush.set(orig);
+        }
+    }
+
+    void run() {
+        try {
+            flushBuffer();
+        } catch (IOException x) {
+            LOGGER.log(Level.FINE, null, x);
+        }
+        reschedule();
+    }
+
+    private static final class Flush implements Runnable {
+
+        /** Since there is no explicit close event, just keep flushing periodically until the stream is collected. */
+        private final Reference<DelayBufferedOutputStream> osr;
+
+        Flush(DelayBufferedOutputStream os) {
+            osr = new WeakReference<>(os);
+        }
+
+        @Override public void run() {
+            DelayBufferedOutputStream os = osr.get();
+            if (os != null) {
+                os.run();
+            }
+        }
+
+    }
+
+    /** @see DelayBufferedOutputStream#flushBuffer */
+    private static final class FlushControlledOutputStream extends FilterOutputStream {
+
+        private final ThreadLocal<Boolean> enableFlush = new ThreadLocal<Boolean>() {
+            @Override protected Boolean initialValue() {
+                return true;
+            }
+        };
+
+        FlushControlledOutputStream(OutputStream out) {
+            super(out);
+        }
+
+        @Override public void write(byte[] b, int off, int len) throws IOException {
+            out.write(b, off, len); // super method writes one byte at a time!
+        }
+
+        @Override public void flush() throws IOException {
+            if (enableFlush.get()) {
+                super.flush();
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/DelayBufferedOutputStream.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/DelayBufferedOutputStream.java
@@ -81,6 +81,13 @@ final class DelayBufferedOutputStream extends BufferedOutputStream {
         reschedule();
     }
 
+    @SuppressWarnings("FinalizeDeclaration") // not ideal, but PhantomReference is more of a hassle
+    @Override protected void finalize() throws Throwable {
+        super.finalize();
+        // Odd that this is not the default behavior for BufferedOutputStream.
+        flush();
+    }
+
     private static final class Flush implements Runnable {
 
         /** Since there is no explicit close event, just keep flushing periodically until the stream is collected. */

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java
@@ -28,9 +28,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.console.AnnotatedLargeText;
 import hudson.console.ConsoleAnnotationOutputStream;
 import hudson.model.BuildListener;
-import hudson.model.StreamBuildListener;
 import hudson.model.TaskListener;
-import hudson.util.StreamTaskListener;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
@@ -115,11 +113,11 @@ public final class FileLogStorage implements LogStorage {
     }
 
     @Override public BuildListener overallListener() throws IOException, InterruptedException {
-        return new StreamBuildListener(new IndexOutputStream(null), StandardCharsets.UTF_8);
+        return new BufferedBuildListener(new IndexOutputStream(null));
     }
 
     @Override public TaskListener nodeListener(FlowNode node) throws IOException, InterruptedException {
-        return new StreamTaskListener(new IndexOutputStream(node.getId()), StandardCharsets.UTF_8);
+        return new BufferedBuildListener(new IndexOutputStream(node.getId()));
     }
 
     private void checkId(String id) throws IOException {

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java
@@ -29,7 +29,6 @@ import hudson.console.AnnotatedLargeText;
 import hudson.console.ConsoleAnnotationOutputStream;
 import hudson.model.BuildListener;
 import hudson.model.TaskListener;
-import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -86,7 +85,7 @@ public final class FileLogStorage implements LogStorage {
     private synchronized void open() throws IOException {
         if (os == null) {
             os = new FileOutputStream(log, true);
-            bos = new BufferedOutputStream(os);
+            bos = new DelayBufferedOutputStream(os);
             if (index.isFile()) {
                 try (BufferedReader r = Files.newBufferedReader(index.toPath(), StandardCharsets.UTF_8)) {
                     // TODO would be faster to scan the file backwards for the penultimate \n, then convert the byte sequence from there to EOF to UTF-8 and set lastId accordingly

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java
@@ -73,8 +73,9 @@ public final class FileLogStorage implements LogStorage {
 
     private final File log;
     private final File index;
-    @SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC", justification = "FB apparently gets confused by what the lock is, and anyway we only care about synchronizing writes")
+    @SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC", justification = "actually it is always accessed within the monitor")
     private FileOutputStream os;
+    @SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC", justification = "we only care about synchronizing writes")
     private OutputStream bos;
     private Writer indexOs;
     private String lastId;

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/TaskListenerDecorator.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/TaskListenerDecorator.java
@@ -158,10 +158,10 @@ public abstract class TaskListenerDecorator implements /* TODO Remotable */ Seri
             filter(Objects::nonNull).
             collect(Collectors.toCollection(ArrayList::new));
         if (decorators.isEmpty()) {
-            return BuildListenerAdapter.wrap(listener);
+            return CloseableTaskListener.of(BuildListenerAdapter.wrap(listener), listener);
         } else {
             Collections.reverse(decorators);
-            return new DecoratedTaskListener(listener, decorators);
+            return CloseableTaskListener.of(new DecoratedTaskListener(listener, decorators), listener);
         }
     }
 
@@ -257,6 +257,37 @@ public abstract class TaskListenerDecorator implements /* TODO Remotable */ Seri
 
         @Override public String toString() {
             return "DecoratedTaskListener[" + delegate + decorators + "]";
+        }
+
+    }
+
+    private static final class CloseableTaskListener implements BuildListener, AutoCloseable {
+
+        static BuildListener of(BuildListener mainDelegate, TaskListener closeDelegate) {
+            if (closeDelegate instanceof AutoCloseable) {
+                return new CloseableTaskListener(mainDelegate, closeDelegate);
+            } else {
+                return mainDelegate;
+            }
+        }
+
+        private static final long serialVersionUID = 1;
+
+        private final @Nonnull TaskListener mainDelegate;
+        private final @Nonnull TaskListener closeDelegate;
+
+        private CloseableTaskListener(TaskListener mainDelegate, TaskListener closeDelegate) {
+            this.mainDelegate = mainDelegate;
+            this.closeDelegate = closeDelegate;
+            assert closeDelegate instanceof AutoCloseable;
+        }
+
+        @Override public PrintStream getLogger() {
+            return mainDelegate.getLogger();
+        }
+
+        @Override public void close() throws Exception {
+            ((AutoCloseable) closeDelegate).close();
         }
 
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
@@ -93,6 +93,7 @@ public abstract class LogStorageTestBase {
         step1.getLogger().println("one #3");
         overall.getLogger().println("pausing");
         overallHtmlPos = assertOverallLog(overallHtmlPos, "<span class=\"pipeline-node-1\">one #2\none #3\n</span>pausing\n", true);
+        // TODO if we produce output from the middle of a step, we need new span blocks
         step1Pos = assertStepLog("1", step1Pos, "one #2\none #3\n", true);
         assertLength("1", step1Pos);
         try { // as above
@@ -173,6 +174,7 @@ public abstract class LogStorageTestBase {
         }
         @Override public Void call() throws Exception {
             listener.getLogger().println(message);
+            listener.getLogger().flush();
             return null;
         }
     }


### PR DESCRIPTION
~Checking whether this addresses [JENKINS-54073](https://issues.jenkins-ci.org/browse/JENKINS-54073). It does not seem to make any positive difference in little local tests but I doubt those are realistic anyway.~ Note that as far as I can tell, freestyle builds [do not buffer](https://github.com/jenkinsci/jenkins/blob/b057abc7b84295969b894d06011e250842c6d09c/core/src/main/java/hudson/model/Run.java#L1887-L1889), and neither did [pre-JEP-210 Pipeline builds](https://github.com/jenkinsci/workflow-job-plugin/blob/workflow-job-2.21/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java#L227-L228).

----

I think I finally tracked down the issue. While this PR still buffers writes to the `log` on master, the main change is ensuring that the `PrintStream` made available remotely (most significantly, to `DurableTaskStep`) refrains from sending every little chunk of output one by one, and also refrains from sending gratuitous `ProxyOutputStream.Flush` packets. More: https://github.com/jenkinsci/workflow-api-plugin/pull/81#discussion_r228196101

Freestyle builds in fact _do_ send little bits of output. I guess nobody cared. After all, it was harder to get lots of agents spewing log output in parallel.

----

The main open question for myself here is the expectation that remote code calls the equivalent of `listener.getLogger().flush()` when it is done with a major task (like a step). If it neglects to do so, any remaining content will get auto-flushed, but out of order in the build log and possibly too late (after the agent has been disconnected or the build completed). This is not exactly compatible (thus the need for https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/85), but on the other hand I cannot think of many cases where code other than `DurableTaskStep` was printing content remotely to begin with—most plugins which print messages do so inside `perform` or similar, on the master.

A possible refinement would be to turn autoflush back on for the remote `PrintStream`, so that `println(String)` and the like are sent immediately, but then modify `DecoratedTaskListener` to extract the underlying `OutputStream` from the `PrintStream delegate.getLogger()`. Thus there would only be one `PrintStream` on top of the stack of delegates, so any calls to it directly would flush, yet `DurableTaskStep.HandlerImpl` would continue to write to the buffered, non-autoflushing `OutputStream` stack, which would be ideal. The problem with this scenario is that decorators then lose access to the `PrintStream` that they sometimes need for synchronization purposes to avoid mangled output under high concurrency, as in https://github.com/jenkinsci/timestamper-plugin/commit/bf1e61c8a57ef434316a41ffbfb4126e88a9f1f9 in https://github.com/jenkinsci/timestamper-plugin/pull/25. I am not sure yet if there is a good resolution to this conflict; if there is, it should be possible to do it compatibly later (since the worst that could happen is that something like https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/85 gratuitously sends one flush packet at the end of a step).