### PR TITLE
[JENKINS-54566] finalize vs. flush

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/log/BufferedBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/BufferedBuildListener.java
@@ -74,7 +74,7 @@ final class BufferedBuildListener implements BuildListener, Closeable, Serializa
         }
 
         private Object readResolve() throws IOException {
-            return new BufferedBuildListener(new DelayBufferedOutputStream(ros, tuning));
+            return new BufferedBuildListener(new GCFlushedOutputStream(new DelayBufferedOutputStream(ros, tuning)));
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/DelayBufferedOutputStream.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/DelayBufferedOutputStream.java
@@ -116,9 +116,9 @@ final class DelayBufferedOutputStream extends BufferedOutputStream {
 
     }
 
-    //
     /**
      * Flushes streams prior to garbage collection.
+     * ({@link BufferedOutputStream} does not do this automatically.)
      * TODO Java 9+ could use java.util.Cleaner
      */
     private static final class FlushRef extends PhantomReference<DelayBufferedOutputStream> {
@@ -134,7 +134,6 @@ final class DelayBufferedOutputStream extends BufferedOutputStream {
                     }
                     LOGGER.log(Level.FINE, "cleaning up phantom {0}", ref.out);
                     try {
-                        // Odd that this is not the default behavior for BufferedOutputStream.
                         ref.out.flush();
                     } catch (IOException x) {
                         LOGGER.log(Level.WARNING, null, x);

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/DelayBufferedOutputStream.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/DelayBufferedOutputStream.java
@@ -98,6 +98,7 @@ final class DelayBufferedOutputStream extends BufferedOutputStream {
     @SuppressWarnings("FinalizeDeclaration") // not ideal, but PhantomReference is more of a hassle
     @Override protected void finalize() throws Throwable {
         super.finalize();
+        Thread.sleep(100); // TODO for FileLogStorageTest#remoting
         // Odd that this is not the default behavior for BufferedOutputStream.
         flush();
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java
@@ -85,7 +85,7 @@ public final class FileLogStorage implements LogStorage {
     private synchronized void open() throws IOException {
         if (os == null) {
             os = new FileOutputStream(log, true);
-            bos = new DelayBufferedOutputStream(os);
+            bos = new GCFlushedOutputStream(new DelayBufferedOutputStream(os));
             if (index.isFile()) {
                 try (BufferedReader r = Files.newBufferedReader(index.toPath(), StandardCharsets.UTF_8)) {
                     // TODO would be faster to scan the file backwards for the penultimate \n, then convert the byte sequence from there to EOF to UTF-8 and set lastId accordingly

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/GCFlushedOutputStream.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/GCFlushedOutputStream.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.log;
+
+import java.io.BufferedOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jenkins.util.Timer;
+
+/**
+ * A stream which will be flushed before garbage collection.
+ * {@link BufferedOutputStream} does not do this automatically.
+ */
+final class GCFlushedOutputStream extends FilterOutputStream {
+    
+    private static final Logger LOGGER = Logger.getLogger(GCFlushedOutputStream.class.getName());
+
+    GCFlushedOutputStream(OutputStream out) {
+        super(out);
+        FlushRef.register(this, out);
+    }
+
+    @Override public void write(byte[] b, int off, int len) throws IOException {
+        out.write(b, off, len); // super method is surprising
+    }
+
+    @Override public String toString() {
+        return "GCFlushedOutputStream[" + out + "]";
+    }
+
+    /**
+     * Flushes streams prior to garbage collection.
+     * ({@link BufferedOutputStream} does not do this automatically.)
+     * TODO Java 9+ could use java.util.Cleaner
+     */
+    private static final class FlushRef extends PhantomReference<GCFlushedOutputStream> {
+
+        private static final ReferenceQueue<GCFlushedOutputStream> rq = new ReferenceQueue<>();
+
+        static {
+            Timer.get().scheduleWithFixedDelay(() -> {
+                while (true) {
+                    FlushRef ref = (FlushRef) rq.poll();
+                    if (ref == null) {
+                        break;
+                    }
+                    LOGGER.log(Level.FINE, "flushing {0}", ref.out);
+                    try {
+                        ref.out.flush();
+                    } catch (IOException x) {
+                        LOGGER.log(Level.WARNING, null, x);
+                    }
+                }
+            }, 0, 10, TimeUnit.SECONDS);
+        }
+
+        static void register(GCFlushedOutputStream fos, OutputStream out) {
+            new FlushRef(fos, out, rq).enqueue();
+        }
+
+        private final OutputStream out;
+
+        private FlushRef(GCFlushedOutputStream fos, OutputStream out, ReferenceQueue<GCFlushedOutputStream> rq) {
+            super(fos, rq);
+            this.out = out;
+        }
+
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
@@ -189,6 +189,7 @@ public abstract class LogStorageTestBase {
             return null;
         }
     }
+    /** Checking behavior of {@link DelayBufferedOutputStream} garbage collection. */
     private static final class GC extends MasterToSlaveCallable<Void, Exception> {
         @Override public Void call() throws Exception {
             System.gc();

--- a/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
@@ -152,6 +152,7 @@ public abstract class LogStorageTestBase {
         VirtualChannel channel = r.createOnlineSlave().getChannel();
         channel.call(new RemotePrint("overall from agent", overall));
         channel.call(new RemotePrint("step from agent", step));
+        channel.call(new GC());
         overallPos = assertOverallLog(overallPos, "overall from agent\n<span class=\"pipeline-node-1\">step from agent\n</span>", true);
         stepPos = assertStepLog("1", stepPos, "step from agent\n", true);
         assertEquals(overallPos, assertOverallLog(overallPos, "", true));
@@ -170,6 +171,13 @@ public abstract class LogStorageTestBase {
         @Override public Void call() throws Exception {
             listener.getLogger().println(message);
             listener.getLogger().flush();
+            return null;
+        }
+    }
+    private static final class GC extends MasterToSlaveCallable<Void, Exception> {
+        @Override public Void call() throws Exception {
+            System.gc();
+            System.runFinalization();
             return null;
         }
     }


### PR DESCRIPTION
[JENKINS-54566](https://issues.jenkins-ci.org/browse/JENKINS-54566)

Amends #81. https://github.com/jenkinsci/remoting/pull/308 suppresses the error, but this should be the actual fix. Note that flushing a soon-to-be-collected stream is intended as a best effort to capture any stray messages not already delivered, due perhaps to callables neglecting to explicitly flush.