### PR TITLE
Update FlowGraphWalker.java

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowGraphWalker.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowGraphWalker.java
@@ -96,6 +96,9 @@ public class FlowGraphWalker implements Iterable<FlowNode> {
             checkForComodification();
             while (!q.isEmpty()) {
                 FlowNode n = q.pop();
+                if (n == null) {
+                    continue;
+                }
                 if (!visited.add(n)) {
                     continue;
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowGraphWalker.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowGraphWalker.java
@@ -48,6 +48,9 @@ public class FlowGraphWalker implements Iterable<FlowNode> {
     public FlowNode next() {
         while (!q.isEmpty()) {
             FlowNode n = q.pop();
+            if (n == null) {
+                continue;
+            }
             if (!visited.add(n))
                 continue;
 


### PR DESCRIPTION
We see many incidents where n.getParents() fail due to NullPointerException