### PR TITLE
Use correct variable for nodeAfter in MemoryFlowChunk constructor

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/MemoryFlowChunk.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/MemoryFlowChunk.java
@@ -45,7 +45,7 @@ public class MemoryFlowChunk implements FlowChunkWithContext {
         this.setNodeBefore(before);
         this.setFirstNode(firstNode);
         this.setLastNode(lastNode);
-        this.setNodeAfter(lastNode);
+        this.setNodeAfter(nodeAfter);
     }
 
     public MemoryFlowChunk() {

--- a/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/MemoryFlowChunkTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/MemoryFlowChunkTest.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.graphanalysis;
+
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class MemoryFlowChunkTest {
+
+    @Test
+    public void constructor() {
+        MockFlowNode start = new MockFlowNode("1");
+        MockFlowNode blockStart = new MockFlowNode("2", start);
+        MockFlowNode blockEnd = new MockFlowNode("3", blockStart);
+        MockFlowNode end = new MockFlowNode("4", blockEnd);
+        MemoryFlowChunk chunk = new MemoryFlowChunk(start, blockStart, blockEnd, end);
+        assertThat(chunk.getNodeBefore(), equalTo(start));
+        assertThat(chunk.getFirstNode(), equalTo(blockStart));
+        assertThat(chunk.getLastNode(), equalTo(blockEnd));
+        assertThat(chunk.getNodeAfter(), equalTo(end));
+    }
+
+    private static class MockFlowNode extends FlowNode {
+        public MockFlowNode(String id, FlowNode... parents) {
+            super(null, id, parents);
+        }
+
+        @Override
+        protected String getTypeDisplayName() {
+            return "Mock FlowNode";
+        }
+    }
+}


### PR DESCRIPTION
Noticed while working on adding some new tests in pipeline-graph-analysis. Thankfully, it doesn't look like there are any callers currently using this overload of the constructor ([here is a GitHub search for MemoryFlowChunk in the jenkinsci org](https://github.com/search?p=1&q=user%3Ajenkinsci+MemoryFlowChunk&type=Code)).