### PR TITLE
[JENKINS-39203] Create new action to mark a FlowNode with a result such as unstable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -29,7 +29,7 @@ import hudson.remoting.ClassFilter;
 import hudson.remoting.ProxyException;
 import javax.annotation.CheckForNull;
 import org.codehaus.groovy.control.MultipleCompilationErrorsException;
-import org.jenkinsci.plugins.workflow.graph.AtomNode;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.output.NullOutputStream;

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -35,7 +35,7 @@ import jenkins.model.Jenkins;
 import org.apache.commons.io.output.NullOutputStream;
 
 /**
- * Attached to {@link AtomNode} that caused an error.
+ * Attached to {@link FlowNode} that caused an error.
  *
  * This has to be Action because it's added after a node is created.
  */

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/WarningAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/WarningAction.java
@@ -1,30 +1,41 @@
 package org.jenkinsci.plugins.workflow.actions;
 
 import hudson.model.Result;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
 /**
- * Action to be attached to a {@link FlowNode} to signify that some non-fatal warning occurred
- * during execution of a {@code Step}.
+ * Action to be attached to a {@link FlowNode} to signify that some non-fatal event occurred
+ * during execution of a {@code Step} but execution continued normally.
  *
- * Visualizations should treat FlowNodes with this action as if the FlowNode's result was
- * {@link Result#UNSTABLE}.
+ * {@link #withMessage} should be used whenever possible to give context to the warning.
+ * Visualizations should treat FlowNodes with this action as if the FlowNode's result was {@link #result}.
  */
-public final class WarningAction implements PersistentAction {
-    private final @Nonnull String message;
+public class WarningAction implements PersistentAction {
+    private @Nonnull Result result;
+    private @CheckForNull String message;
 
-    public WarningAction(@Nonnull String message) {
-        this.message = message;
+    public WarningAction(@Nonnull Result result) {
+        this.result = result;
     }
 
-    public @Nonnull String getMessage() {
+    public WarningAction withMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    public @CheckForNull String getMessage() {
         return message;
+    }
+
+    public @Nonnull Result getResult() {
+        return result;
     }
 
     @Override
     public String getDisplayName() {
-        return "Warning: " + message;
+        return "Warning" + (message != null ? ": " + message : "");
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/WarningAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/WarningAction.java
@@ -1,0 +1,36 @@
+package org.jenkinsci.plugins.workflow.actions;
+
+import hudson.model.Result;
+import javax.annotation.Nonnull;
+
+/**
+ * This action can be attached to a {@link FlowNode} to signify that some non-fatal
+ * warning occurred during execution. Visualizations should treat FlowNodes with this
+ * action as if the FlowNode's result was {@link Result#UNSTABLE}.
+ */
+public final class WarningAction implements PersistentAction {
+    private final @Nonnull String message;
+
+    public WarningAction(@Nonnull String message) {
+        this.message = message;
+    }
+
+    public @Nonnull String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Warning: " + message;
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/WarningAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/WarningAction.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.workflow.actions;
 
 import hudson.model.Result;
 import javax.annotation.Nonnull;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
 /**
  * This action can be attached to a {@link FlowNode} to signify that some non-fatal

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/WarningAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/WarningAction.java
@@ -5,9 +5,11 @@ import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
 /**
- * This action can be attached to a {@link FlowNode} to signify that some non-fatal
- * warning occurred during execution. Visualizations should treat FlowNodes with this
- * action as if the FlowNode's result was {@link Result#UNSTABLE}.
+ * Action to be attached to a {@link FlowNode} to signify that some non-fatal warning occurred
+ * during execution of a {@code Step}.
+ *
+ * Visualizations should treat FlowNodes with this action as if the FlowNode's result was
+ * {@link Result#UNSTABLE}.
  */
 public final class WarningAction implements PersistentAction {
     private final @Nonnull String message;

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -48,6 +48,7 @@ import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.PersistentAction;
+import org.jenkinsci.plugins.workflow.actions.WarningAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graphanalysis.FlowScanningUtils;
 import org.jenkinsci.plugins.workflow.graphanalysis.NodeStepTypePredicate;
@@ -274,9 +275,6 @@ public abstract class FlowNode extends Actionable implements Saveable {
 
     /**
      * Returns colored orb that represents the current state of this node.
-     *
-     * TODO: this makes me wonder if we should support other colored states,
-     * like unstable and aborted --- seems useful.
      */
     @Exported
     public BallColor getIconColor() {
@@ -284,10 +282,13 @@ public abstract class FlowNode extends Actionable implements Saveable {
         BallColor c = null;
         if(error != null) {
             if(error.getError() instanceof FlowInterruptedException) {
+                // TODO: Use FlowInterruptedException.getResult() to determine ball color.
                 c = BallColor.ABORTED;
             } else {
                 c = BallColor.RED;
             }
+        } else if (getPersistentAction(WarningAction.class) != null) {
+            c = BallColor.YELLOW;
         } else {
             c = BallColor.BLUE;
         }


### PR DESCRIPTION
See [JENKINS-39203](https://issues.jenkins-ci.org/browse/JENKINS-39203). (I am intentionally not updating the status of that ticket or assigning it to myself until I am ready to merge/release all relevant changes to avoid giving users premature hope of a fix and so that I have clear answers for what will and won't work and when any fixes will be released.) Subsumes #63.

This PR adds a new action named `WarningAction`. This action can be stored on a `FlowNode` to mark that although it completed successfully, some kind of non-fatal problem occurred. For now, this action will be used by Blue Ocean to mark stages containing a `FlowNode` with a `WarningAction` as `Result.UNSTABLE`.

In the future, if we wanted to add the ability to track some new kind of non-fatal result, we could update `WarningAction` to store a custom `Result` (or similar) and use that in visualizations to modify how the action should be displayed.

Upstream PRs:

* https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/83
* https://github.com/jenkinsci/pipeline-graph-analysis-plugin/pull/25
* https://github.com/jenkinsci/blueocean-plugin/pull/1954
* https://github.com/jenkinsci/junit-plugin/pull/118
* https://github.com/jenkinsci/warnings-ng-plugin/pull/58