### PR TITLE
[JENKINS-57805] Harden bruteForceScanForEnclosingBlocks against nodes with no parents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.42</version>
+        <version>3.43</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/StandardGraphLookupView.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/StandardGraphLookupView.java
@@ -147,6 +147,9 @@ public final class StandardGraphLookupView implements GraphLookupView, GraphList
             }
 
             // Now see if we have a winner among parents
+            if (current.getParents().isEmpty()) {
+                return null;
+            }
             FlowNode parent = current.getParents().get(0);
             if (parent instanceof BlockStartNode) {
                 nearestEnclosingBlock.put(current.getId(), parent.getId());


### PR DESCRIPTION
See [JENKINS-57805](https://issues.jenkins-ci.org/browse/JENKINS-57805).

This PR keeps `bruteForceScanForEnclosingBlocks` from throwing an `IndexOutOfBoundsException` when it encounters a `FlowNode` with no parents.