### PR TITLE
[JENKINS-45693] Remove beta mark from TaskListenerDecorator

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/log/TaskListenerDecorator.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/TaskListenerDecorator.java
@@ -54,8 +54,6 @@ import jenkins.util.JenkinsJVM;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.steps.BodyInvoker;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.Beta;
 
 /**
  * A way of decorating output from a {@link TaskListener}.
@@ -67,7 +65,6 @@ import org.kohsuke.accmod.restrictions.Beta;
  * Any master-side configuration should thus be saved into instance fields when the decorator is constructed.
  * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-45693">JENKINS-45693</a>
  */
-@Restricted(Beta.class)
 public abstract class TaskListenerDecorator implements /* TODO Remotable */ Serializable {
 
     private static final long serialVersionUID = 1;


### PR DESCRIPTION
This API was introduced ten months ago in #76 and has proven itself irreplaceable in https://github.com/jenkinsci/timestamper-plugin/pull/25 and https://github.com/jenkinsci/kubernetes-plugin/pull/494, as well as one proprietary usage I am aware of by @olamy. I think it is time to be considered a supported API.