### PR TITLE
Fix incompatibility between workflow-api tests and ansicolor plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.37</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.150.1</jenkins.version>
+        <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <workflow-support-plugin.version>2.21</workflow-support-plugin.version>
@@ -122,12 +122,6 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
             <version>2.22</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>ansicolor</artifactId>
-            <version>0.6.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.37</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.138.4</jenkins.version>
+        <jenkins.version>2.150.1</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <workflow-support-plugin.version>2.21</workflow-support-plugin.version>
@@ -122,6 +122,12 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
             <version>2.22</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>ansicolor</artifactId>
+            <version>0.6.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
@@ -26,6 +26,8 @@ package org.jenkinsci.plugins.workflow.log;
 
 import hudson.console.AnnotatedLargeText;
 import hudson.console.HyperlinkNote;
+import hudson.model.Action;
+import hudson.model.Result;
 import hudson.model.TaskListener;
 import hudson.remoting.Channel;
 import hudson.remoting.VirtualChannel;
@@ -42,13 +44,18 @@ import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.function.BiFunction;
 import java.util.logging.Level;
+import jenkins.model.CauseOfInterruption;
 import jenkins.security.MasterToSlaveCallable;
+import org.acegisecurity.Authentication;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.io.output.NullWriter;
 import org.apache.commons.io.output.WriterOutputStream;
 import static org.hamcrest.Matchers.*;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -321,8 +328,59 @@ public abstract class LogStorageTestBase {
     }
 
     private static class MockNode extends FlowNode {
-        MockNode(String id) {super(null, id);}
+        MockNode(String id) {super(new MockFlowExecution(), id);}
         @Override protected String getTypeDisplayName() {return null;}
     }
 
+    private static class MockFlowExecution extends FlowExecution {
+        @Override
+        public void start() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public FlowExecutionOwner getOwner() {
+            return null;
+        }
+
+        @Override
+        public List<FlowNode> getCurrentHeads() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isCurrentHead(FlowNode n) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void interrupt(Result r, CauseOfInterruption... causes) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addListener(GraphListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public FlowNode getNode(String id) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Authentication getAuthentication() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<Action> loadActions(FlowNode node) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void saveActions(FlowNode node, List<Action> actions) {
+            throw new UnsupportedOperationException();
+        }
+    }
 }


### PR DESCRIPTION
### Problem

This PR addresses an incompatibility discovered in jenkinsci/bom#60 when running `workflow-api` tests in the Plugin Compatibility Tester (PCT) with `ansicolor` 0.6.0 or greater. This results in the following exception:

```
java.lang.NullPointerException
	at hudson.plugins.ansicolor.ColorConsoleAnnotator$Factory.newInstance(ColorConsoleAnnotator.java:114)
	at hudson.console.ConsoleAnnotator._for(ConsoleAnnotator.java:151)
	at hudson.console.ConsoleAnnotator.initial(ConsoleAnnotator.java:140)
	at hudson.console.AnnotatedLargeText.createAnnotator(AnnotatedLargeText.java:138)
	at hudson.console.AnnotatedLargeText.writeHtmlTo(AnnotatedLargeText.java:168)
	at org.jenkinsci.plugins.workflow.log.LogStorageTestBase.mangledLines(LogStorageTestBase.java:252)
```

### Evaluation

The NPE is on [line 114](https://github.com/jenkinsci/ansicolor-plugin/blob/2c651751ff7a2d8fea3fa0612693a82fbcd85fbc/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java#L114):

```java
FlowExecutionOwner owner = node.getExecution().getOwner();
```

So clearly `node.getExecution()` must be null. Where is it coming from? From [`LogStorageBase#MockNode`](https://github.com/jenkinsci/workflow-api-plugin/blob/92e2b80f52d909faf06d17a6d19ad4f7199a87b5/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java#L323-L326), which extends `FlowNode` but whose `getExecution()` method returns null, violating the contract of `FlowNode` (whose `getExecution()` method is marked `@Nonnull`). `ansicolor` legitimately expects to be able to call `getExecution()` and get a non-null value in return. When it gets null, it fails.

### Solution

The solution is to make `LogStorageBase#MockNode` respect `FlowNode`'s contract by returning a non-null value in its `getExecution()` method. We do this by creating a `MockFlowExecution` and having `MockFlowNode` return it. All of `MockFlowExecution`'s methods throw `UnsupportedOperationException` except for the one that is needed by `ansicolor`, `getOwner()`, which returns null. `ansicolor` correctly deals with the case where the owner is null.

### Implementation

To reproduce the issue, I had to add `ansicolor` to the test-scoped dependencies for this plugin. And in order to get ansicolor 0.6.0 or later to load, I had to bump the Jenkins version from 2.138.4 to 2.145 or later (I chose 2.150.1 to stay on an LTS release).