### PR TITLE
Proxy exceptions defined in Pipeline scripts

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.actions;
 
+import groovy.lang.GroovyClassLoader;
 import groovy.lang.MissingMethodException;
 import hudson.remoting.ClassFilter;
 import hudson.remoting.ProxyException;
@@ -64,6 +65,11 @@ public class ErrorAction implements PersistentAction {
     private boolean isUnserializableException(@CheckForNull Throwable error) {
         if (error == null) {
             return false;
+        }
+        // If the exception was defined in a Pipeline script, we don't want to serialize it
+        // directly to avoid leaking a reference to the class loader for the Pipeline script.
+        if (error.getClass().getClassLoader() instanceof GroovyClassLoader) {
+            return true;
         }
         if (error instanceof MultipleCompilationErrorsException || error instanceof MissingMethodException) {
             return true;

--- a/src/test/java/org/jenkinsci/plugins/workflow/actions/ErrorActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/actions/ErrorActionTest.java
@@ -154,4 +154,16 @@ public class ErrorActionTest {
         final NullObject nil = NullObject.getNullObject();
     }
 
+    @Test public void userDefinedError() throws Exception {
+        WorkflowJob p = r.createProject(WorkflowJob.class);
+        p.setDefinition(new CpsFlowDefinition(
+                "class MyException extends Exception {\n" +
+                "  MyException(String message) { super(message) }\n" +
+                "}\n" +
+                "throw new MyException('test')\n",
+                true));
+        WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+        assertThat(b.getExecution().getCauseOfFailure(), Matchers.instanceOf(ProxyException.class));
+    }
+
 }


### PR DESCRIPTION
An investigation into a memory leak revealed that if classes defined in a Pipeline script are serialized by `XStream`, `XStream` holds a reference to the class and thus its class loader, which prevents the class loader from being garbage collected. One way this can happen is if the Pipeline throws a user-defined exception. To avoid the problem in that case, we proxy these exceptions so that they do not reference the original class.