### PR TITLE
If a FlowNode terminated in an error, display the stack trace under Pipeline Steps

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/graph/FlowNode/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/graph/FlowNode/index.jelly
@@ -39,6 +39,14 @@
               </li>
           </j:forEach>
       </ul>
+      <j:if test="${it.error != null}">
+          <h2>${%Error}</h2>
+          <pre>
+              <code>
+                  ${h.printThrowable(it.error.error)}
+              </code>
+          </pre>
+      </j:if>
     </l:main-panel>
   </l:layout>
 </j:jelly>


### PR DESCRIPTION
Would be useful for tracking down some recent cryptic ci.jenkins.io outages.