### PR TITLE
Remove unused imports and fix collections empty objects

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/FilePathUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/FilePathUtils.java
@@ -24,7 +24,6 @@
 
 package org.jenkinsci.plugins.workflow;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Computer;

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ArgumentsAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ArgumentsAction.java
@@ -185,7 +185,7 @@ public abstract class ArgumentsAction implements PersistentAction {
     @Nonnull
     public static Map<String, Object> getFilteredArguments(@Nonnull FlowNode n) {
         ArgumentsAction act = n.getPersistentAction(ArgumentsAction.class);
-        return act != null ? act.getFilteredArguments() : Collections.EMPTY_MAP;
+        return act != null ? act.getFilteredArguments() : Collections.emptyMap();
     }
 
     /** Return a tidy string description for the step arguments, or null if none is present or we can't make one

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -26,7 +26,6 @@ package org.jenkinsci.plugins.workflow.actions;
 
 import groovy.lang.GroovyClassLoader;
 import groovy.lang.MissingMethodException;
-import hudson.remoting.ClassFilter;
 import hudson.remoting.ProxyException;
 import javax.annotation.CheckForNull;
 import org.codehaus.groovy.control.MultipleCompilationErrorsException;

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/LogAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/LogAction.java
@@ -25,7 +25,6 @@
 package org.jenkinsci.plugins.workflow.actions;
 
 import hudson.console.AnnotatedLargeText;
-import hudson.model.Action;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/TagsAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/TagsAction.java
@@ -24,7 +24,6 @@
 
 package org.jenkinsci.plugins.workflow.actions;
 
-import hudson.model.Action;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
 import javax.annotation.CheckForNull;
@@ -32,7 +31,6 @@ import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Tracks arbitrary annotations on FlowNode used for a variety of purposes
@@ -102,7 +100,7 @@ public class TagsAction implements PersistentAction {
     @Nonnull
     public static Map<String,String> getTags(@Nonnull  FlowNode node) {
         TagsAction tagAction = node.getAction(TagsAction.class);
-        return (tagAction == null) ? (Map)(Collections.emptyMap()) : tagAction.getTags();
+        return (tagAction == null) ? Collections.emptyMap() : tagAction.getTags();
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/BlockEndNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/BlockEndNode.java
@@ -28,8 +28,6 @@ import java.io.IOException;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
 /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/GraphLookupView.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/GraphLookupView.java
@@ -1,7 +1,5 @@
 package org.jenkinsci.plugins.workflow.graph;
 
-import org.kohsuke.accmod.Restricted;
-
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.util.Iterator;

--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/StandardGraphLookupView.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/StandardGraphLookupView.java
@@ -1,10 +1,8 @@
 package org.jenkinsci.plugins.workflow.graph;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
-import org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -12,7 +10,6 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/AbstractFlowScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/AbstractFlowScanner.java
@@ -25,7 +25,6 @@
 package org.jenkinsci.plugins.workflow.graphanalysis;
 
 import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
@@ -98,7 +97,7 @@ public abstract class AbstractFlowScanner implements Iterable <FlowNode>, Filter
 
     protected FlowNode myNext;
 
-    protected Collection<FlowNode> myBlackList = Collections.EMPTY_SET;
+    protected Collection<FlowNode> myBlackList = Collections.emptySet();
 
     /** When checking for blacklist membership, we convert to a hashset when checking more than this many elements */
     protected static final int MAX_LIST_CHECK_SIZE = 5;
@@ -107,7 +106,7 @@ public abstract class AbstractFlowScanner implements Iterable <FlowNode>, Filter
     @Nonnull
     protected Collection<FlowNode> convertToFastCheckable(@CheckForNull Collection<FlowNode> nodeCollection) {
         if (nodeCollection == null || nodeCollection.size()==0) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         } else  if (nodeCollection.size() == 1) {
             return Collections.singleton(nodeCollection.iterator().next());
         } else if (nodeCollection instanceof HashSet) {
@@ -149,7 +148,7 @@ public abstract class AbstractFlowScanner implements Iterable <FlowNode>, Filter
         if (heads == null) {
             return false;
         }
-        return setup(heads, Collections.EMPTY_SET);
+        return setup(heads, Collections.emptySet());
     }
 
     /**
@@ -169,7 +168,7 @@ public abstract class AbstractFlowScanner implements Iterable <FlowNode>, Filter
         if (head == null) {
             return false;
         }
-        return setup(Collections.singleton(head), Collections.EMPTY_SET);
+        return setup(Collections.singleton(head), Collections.emptySet());
     }
 
     /** Reset internal state so that we can begin walking a new flow graph
@@ -296,7 +295,7 @@ public abstract class AbstractFlowScanner implements Iterable <FlowNode>, Filter
                                         @CheckForNull Collection<FlowNode> blackList,
                                         Predicate<FlowNode> matchCondition) {
         if (!setup(heads, blackList)) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
         ArrayList<FlowNode> nodes = new ArrayList<FlowNode>();
@@ -312,7 +311,7 @@ public abstract class AbstractFlowScanner implements Iterable <FlowNode>, Filter
     @Nonnull
     public List<FlowNode> allNodes(@CheckForNull Collection<FlowNode> heads) {
         if (!setup(heads)) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         List<FlowNode> nodes = new ArrayList<FlowNode>();
         for (FlowNode f : this) {
@@ -324,7 +323,7 @@ public abstract class AbstractFlowScanner implements Iterable <FlowNode>, Filter
     /** Convenience method to get the list of all {@link FlowNode}s for the execution, in iterator order. */
     @Nonnull
     public List<FlowNode> allNodes(@CheckForNull FlowExecution exec) {
-        return (exec == null) ? Collections.EMPTY_LIST : allNodes(exec.getCurrentHeads());
+        return (exec == null) ? Collections.emptyList() : allNodes(exec.getCurrentHeads());
     }
 
     /** Syntactic sugar for {@link #filteredNodes(Collection, Collection, Predicate)} with no blackList nodes */

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/DepthFirstScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/DepthFirstScanner.java
@@ -24,25 +24,16 @@
 
 package org.jenkinsci.plugins.workflow.graphanalysis;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
 import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
-import java.lang.reflect.Array;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 
 /** Does a simple and somewhat efficient depth-first search of all FlowNodes in the DAG.
  *

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/LinearScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/LinearScanner.java
@@ -58,7 +58,7 @@ public class LinearScanner extends AbstractFlowScanner {
     protected void reset() {
         this.myCurrent = null;
         this.myNext = null;
-        this.myBlackList = Collections.EMPTY_SET;
+        this.myBlackList = Collections.emptySet();
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/NodeStepNamePredicate.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/NodeStepNamePredicate.java
@@ -24,21 +24,16 @@
 package org.jenkinsci.plugins.workflow.graphanalysis;
 
 import com.google.common.base.Predicate;
-import org.apache.commons.digester.annotations.handlers.MethodHandler;
 import org.jenkinsci.plugins.workflow.graph.FlowEndNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graph.FlowStartNode;
 import org.jenkinsci.plugins.workflow.graph.StepNode;
-import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.lang.invoke.MethodHandle;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /** Predicate that matches {@link FlowNode}s (specifically {@link StepNode}s) with a specific {@link StepDescriptor} name.
  *  May be used in preference to {@link NodeStepTypePredicate} in cases whern dependency structures prevent import

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/NodeStepTypePredicate.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/NodeStepTypePredicate.java
@@ -28,7 +28,6 @@ import org.jenkinsci.plugins.workflow.graph.FlowEndNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graph.FlowStartNode;
 import org.jenkinsci.plugins.workflow.graph.StepNode;
-import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ParallelMemoryFlowChunk.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ParallelMemoryFlowChunk.java
@@ -29,7 +29,6 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 


### PR DESCRIPTION
- Remove unused imports
- Use `Collections.empty*()` as it doesn't generate a conversion warning