### PR TITLE
Fix bad assertion in TestVisitor#assertNoIllegalNullsInEvents

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/TestVisitor.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/TestVisitor.java
@@ -242,7 +242,7 @@ public class TestVisitor implements SimpleChunkVisitor {
             Assert.assertNotNull("Callback with illegally null node: "+ce, id);
             if (ce.type == CallType.PARALLEL_START || ce.type == CallType.PARALLEL_END
                     || ce.type == CallType.PARALLEL_BRANCH_START || ce.type == CallType.PARALLEL_BRANCH_END) {
-                Assert.assertNotNull("Parallel event with illegally null parallel start node ID: "+ce, ce.ids[0]);
+                Assert.assertNotEquals("Parallel event with illegally null parallel start node ID: " + ce, -1, ce.ids[0]);
             }
         }
     }


### PR DESCRIPTION
Noticed this while looking through some IntelliJ warnings. This assertion as-written is always true because `ce.ids` is a primitive `int[]`. What was really meant was to check if the integer is -1. This is because the integers in the data structure are initialized to -1 and only filled in if the corresponding value in `FlowNode` is non-null:

```
public static class CallEntry {
    CallType type;
    int[] ids = {-1, -1, -1, -1};

    public void setIds(FlowNode... nodes) {
        for (int i=0; i<nodes.length; i++) {
            if (nodes[i] == null) {
                ids[i] = -1;
            } else {
                ids[i] = Integer.parseInt(nodes[i].getId());
            }
        }
    }
    [...]
}
```