### PR TITLE
Fix memory leak of GroovyClassLoaders

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -30,7 +30,6 @@ import groovy.lang.MissingPropertyException;
 import hudson.remoting.ProxyException;
 import javax.annotation.CheckForNull;
 import org.codehaus.groovy.control.MultipleCompilationErrorsException;
-import org.codehaus.groovy.tools.GroovyClass;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;

--- a/src/test/java/org/jenkinsci/plugins/workflow/actions/ErrorActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/actions/ErrorActionTest.java
@@ -166,4 +166,11 @@ public class ErrorActionTest {
         assertThat(b.getExecution().getCauseOfFailure(), Matchers.instanceOf(ProxyException.class));
     }
 
+    @Test public void missingPropertyExceptionMemoryLeak() throws Exception {
+        WorkflowJob p = r.createProject(WorkflowJob.class);
+        p.setDefinition(new CpsFlowDefinition("FOO", false));
+        WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+        assertThat(b.getExecution().getCauseOfFailure(), Matchers.instanceOf(ProxyException.class));
+    }
+
 }


### PR DESCRIPTION
MissingPropertyExceptions thrown due to Pipeline scripts can, given the
right circumstances, contain references indirect references to the
Groovy class loader for the pipeline execution. A memory leak will
occur if the exception is saved in a ErrorAction, i.e. if the exception
flies all the way or passes a step before it is caught and treated.

In more detail, if the pipeline code tries to lookup a missing property
in the WorkflowScript class instance, then a MissingPropertyException
will be thrown and the type field in the exception will contain a link
to the WorkflowScript instance, which in turn contains a static link to
the Groovy class loader.