### PR TITLE
Remove trilead reference

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/log/ConsoleAnnotators.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/ConsoleAnnotators.java
@@ -36,6 +36,8 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import static java.lang.Math.abs;
+
+import java.nio.charset.Charset;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 import javax.crypto.Cipher;
@@ -98,7 +100,7 @@ public class ConsoleAnnotators {
         }
         StaplerResponse rsp = Stapler.getCurrentResponse();
         if (rsp != null) {
-            rsp.setHeader("X-ConsoleAnnotator", new String(Base64.getEncoder().encode(baos.toByteArray())));
+            rsp.setHeader("X-ConsoleAnnotator", new String(Base64.getEncoder().encode(baos.toByteArray()), Charset.defaultCharset()));
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/ConsoleAnnotators.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/ConsoleAnnotators.java
@@ -26,7 +26,6 @@ package org.jenkinsci.plugins.workflow.log;
 
 import com.jcraft.jzlib.GZIPInputStream;
 import com.jcraft.jzlib.GZIPOutputStream;
-import com.trilead.ssh2.crypto.Base64;
 import hudson.console.AnnotatedLargeText;
 import hudson.console.ConsoleAnnotationOutputStream;
 import hudson.console.ConsoleAnnotator;
@@ -37,6 +36,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import static java.lang.Math.abs;
+import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
@@ -69,7 +69,7 @@ public class ConsoleAnnotators {
                 @SuppressWarnings("deprecation") // TODO still used in the AnnotatedLargeText version
                 Cipher sym = PASSING_ANNOTATOR.decrypt();
                 try (ObjectInputStream ois = new ObjectInputStreamEx(new GZIPInputStream(
-                        new CipherInputStream(new ByteArrayInputStream(Base64.decode(base64.toCharArray())), sym)),
+                        new CipherInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(base64)), sym)),
                         Jenkins.get().pluginManager.uberClassLoader,
                         ClassFilter.DEFAULT)) {
                     long timestamp = ois.readLong();
@@ -98,7 +98,7 @@ public class ConsoleAnnotators {
         }
         StaplerResponse rsp = Stapler.getCurrentResponse();
         if (rsp != null) {
-            rsp.setHeader("X-ConsoleAnnotator", new String(Base64.encode(baos.toByteArray())));
+            rsp.setHeader("X-ConsoleAnnotator", new String(Base64.getEncoder().encode(baos.toByteArray())));
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/ConsoleAnnotators.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/ConsoleAnnotators.java
@@ -71,7 +71,7 @@ public class ConsoleAnnotators {
                 @SuppressWarnings("deprecation") // TODO still used in the AnnotatedLargeText version
                 Cipher sym = PASSING_ANNOTATOR.decrypt();
                 try (ObjectInputStream ois = new ObjectInputStreamEx(new GZIPInputStream(
-                        new CipherInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(base64)), sym)),
+                        new CipherInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(base64.getBytes(StandardCharsets.UTF_8))), sym)),
                         Jenkins.get().pluginManager.uberClassLoader,
                         ClassFilter.DEFAULT)) {
                     long timestamp = ois.readLong();

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/ConsoleAnnotators.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/ConsoleAnnotators.java
@@ -100,7 +100,7 @@ public class ConsoleAnnotators {
         }
         StaplerResponse rsp = Stapler.getCurrentResponse();
         if (rsp != null) {
-            rsp.setHeader("X-ConsoleAnnotator", new String(Base64.getEncoder().encode(baos.toByteArray()), Charset.defaultCharset()));
+            rsp.setHeader("X-ConsoleAnnotator", new String(Base64.getEncoder().encode(baos.toByteArray()), StandardCharsets.US_ASCII));
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/ConsoleAnnotators.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/ConsoleAnnotators.java
@@ -37,7 +37,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import static java.lang.Math.abs;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 import javax.crypto.Cipher;


### PR DESCRIPTION
Fixes timestamper plugin tests failing on 2.190.x

Ref:
https://ci.jenkins.io/blue/organizations/jenkins/Tools%2Fbom/detail/PR-110/26/pipeline/163
https://ci.jenkins.io/blue/rest/organizations/jenkins/pipelines/Tools/pipelines/bom/branches/PR-110/runs/26/nodes/167/log/?start=0

Could I please get a release so it can be consumed in timestamper and then in the bom