### PR TITLE
Update parent POM, minimum core version, and plugin BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.0-beta-6</version>
+        <version>4.1</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.41</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.164.3</jenkins.version>
+        <jenkins.version>2.176.4</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
@@ -73,7 +73,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.164.x</artifactId>
+                <artifactId>bom-2.176.x</artifactId>
                 <version>9</version>
                 <scope>import</scope>
                 <type>pom</type>


### PR DESCRIPTION
This plugin was already on a 4.x version of the parent, so I don't think it would encounter any build errors when testing against 2.222.x, but I want to go ahead and align all of the main Pipeline plugins on the same core version.