### PR TITLE
[JENKINS-62303] Jenkins.MANAGE users access to global config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.41</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.176.4</jenkins.version>
+        <jenkins.version>2.222.3</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
@@ -132,6 +132,13 @@
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>apache-httpcomponents-client-4-api</artifactId>
           <scope>test</scope>
+        </dependency>
+        <!-- Extracted from core at 2.190.1 -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>trilead-api</artifactId>
+            <version>1.0.6</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.41</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.222.3</jenkins.version>
+        <jenkins.version>2.176.4</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
@@ -132,13 +132,6 @@
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>apache-httpcomponents-client-4-api</artifactId>
           <scope>test</scope>
-        </dependency>
-        <!-- Extracted from core at 2.190.1 -->
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>trilead-api</artifactId>
-            <version>1.0.6</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel.java
@@ -80,13 +80,13 @@ public class GlobalDefaultFlowDurabilityLevel extends AbstractDescribableImpl<Gl
 
         // TODO: remove when Jenkins core baseline is 2.222+
         Permission getJenkinsManageOrAdmin() {
-            Permission systemRead;
+            Permission manage;
             try { // System Read is available starting from Jenkins 2.222 (https://jenkins.io/changelog/#v2.222). See JEP-224 for more info
-                systemRead = (Permission) ReflectionUtils.getPublicProperty(Jenkins.get(), "SYSTEM_READ");
+                manage = (Permission) ReflectionUtils.getPublicProperty(Jenkins.get(), "MANAGE");
             } catch (IllegalArgumentException | InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
-                systemRead = Jenkins.ADMINISTER;
+                manage = Jenkins.ADMINISTER;
             }
-            return systemRead;
+            return manage;
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel.java
@@ -3,11 +3,13 @@ package org.jenkinsci.plugins.workflow.flow;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import hudson.security.Permission;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 /**
  * Supports a global default durability level for users
@@ -67,6 +69,12 @@ public class GlobalDefaultFlowDurabilityLevel extends AbstractDescribableImpl<Gl
 
         public static FlowDurabilityHint[] getDurabilityHintValues() {
             return FlowDurabilityHint.values();
+        }
+
+        @Nonnull
+        @Override
+        public Permission getRequiredGlobalConfigPagePermission() {
+            return Jenkins.MANAGE;
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel.java
@@ -74,6 +74,7 @@ public class GlobalDefaultFlowDurabilityLevel extends AbstractDescribableImpl<Gl
         }
 
         @Nonnull
+        // TODO: Add @Override when Jenkins core baseline is 2.222+
         public Permission getRequiredGlobalConfigPagePermission() {
             return getJenkinsManageOrAdmin();
         }
@@ -81,7 +82,7 @@ public class GlobalDefaultFlowDurabilityLevel extends AbstractDescribableImpl<Gl
         // TODO: remove when Jenkins core baseline is 2.222+
         Permission getJenkinsManageOrAdmin() {
             Permission manage;
-            try { // System Read is available starting from Jenkins 2.222 (https://jenkins.io/changelog/#v2.222). See JEP-224 for more info
+            try { // Manage is available starting from Jenkins 2.222 (https://jenkins.io/changelog/#v2.222). See JEP-223 for more info
                 manage = (Permission) ReflectionUtils.getPublicProperty(Jenkins.get(), "MANAGE");
             } catch (IllegalArgumentException | InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
                 manage = Jenkins.ADMINISTER;

--- a/src/test/java/org/jenkinsci/plugins/workflow/flow/DurabilityBasicsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/flow/DurabilityBasicsTest.java
@@ -97,8 +97,7 @@ public class DurabilityBasicsTest {
 
     // TODO: remove when Jenkins core baseline is 2.222+
     private Permission getJenkinsManage() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        Permission systemRead;
-        // System Read is available starting from Jenkins 2.222 (https://jenkins.io/changelog/#v2.222). See JEP-224 for more info
-        return (Permission) ReflectionUtils.getPublicProperty(Jenkins.get(), "SYSTEM_READ");
+        // Jenkins.MANAGE is available starting from Jenkins 2.222 (https://jenkins.io/changelog/#v2.222). See JEP-224 for more info
+        return (Permission) ReflectionUtils.getPublicProperty(Jenkins.get(), "MANAGE");
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/flow/DurabilityBasicsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/flow/DurabilityBasicsTest.java
@@ -97,7 +97,7 @@ public class DurabilityBasicsTest {
 
     // TODO: remove when Jenkins core baseline is 2.222+
     private Permission getJenkinsManage() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        // Jenkins.MANAGE is available starting from Jenkins 2.222 (https://jenkins.io/changelog/#v2.222). See JEP-224 for more info
+        // Jenkins.MANAGE is available starting from Jenkins 2.222 (https://jenkins.io/changelog/#v2.222). See JEP-223 for more info
         return (Permission) ReflectionUtils.getPublicProperty(Jenkins.get(), "MANAGE");
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/flow/DurabilityBasicsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/flow/DurabilityBasicsTest.java
@@ -1,17 +1,22 @@
 package org.jenkinsci.plugins.workflow.flow;
 
+import hudson.ExtensionList;
 import hudson.Functions;
 import hudson.model.Descriptor;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
+import hudson.security.Permission;
+import hudson.util.ReflectionUtils;
 import jenkins.model.Jenkins;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -59,6 +64,13 @@ public class DurabilityBasicsTest {
     @Test
     public void managePermissionShouldAccessGlobalConfig() {
         r.then(r -> {
+            Permission jenkinsManage;
+            try {
+                jenkinsManage = getJenkinsManage();
+            } catch (Exception e) {
+                Assume.assumeTrue("Jenkins baseline is too old for this test (requires Jenkins.MANAGE)", false);
+                return;
+            }
             final String USER = "user";
             final String MANAGER = "manager";
             r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
@@ -68,7 +80,7 @@ public class DurabilityBasicsTest {
 
                     // Read and Manage
                     .grant(Jenkins.READ).everywhere().to(MANAGER)
-                    .grant(Jenkins.MANAGE).everywhere().to(MANAGER)
+                    .grant(jenkinsManage).everywhere().to(MANAGER)
             );
 
             try (ACLContext c = ACL.as(User.getById(USER, true))) {
@@ -81,5 +93,12 @@ public class DurabilityBasicsTest {
                 assertTrue("Global configuration should be accessible to MANAGE users", found.isPresent());
             }
         });
+    }
+
+    // TODO: remove when Jenkins core baseline is 2.222+
+    private Permission getJenkinsManage() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        Permission systemRead;
+        // System Read is available starting from Jenkins 2.222 (https://jenkins.io/changelog/#v2.222). See JEP-224 for more info
+        return (Permission) ReflectionUtils.getPublicProperty(Jenkins.get(), "SYSTEM_READ");
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/flow/DurabilityBasicsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/flow/DurabilityBasicsTest.java
@@ -1,9 +1,21 @@
 package org.jenkinsci.plugins.workflow.flow;
 
+import hudson.Functions;
+import hudson.model.Descriptor;
+import hudson.model.User;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
+import jenkins.model.Jenkins;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Sam Van Oort
@@ -41,6 +53,33 @@ public class DurabilityBasicsTest {
             GlobalDefaultFlowDurabilityLevel.DescriptorImpl level = r.jenkins.getExtensionList(GlobalDefaultFlowDurabilityLevel.DescriptorImpl.class).get(0);
             level.setDurabilityHint(FlowDurabilityHint.PERFORMANCE_OPTIMIZED);
             Assert.assertEquals(FlowDurabilityHint.PERFORMANCE_OPTIMIZED, GlobalDefaultFlowDurabilityLevel.getDefaultDurabilityHint());
+        });
+    }
+
+    @Test
+    public void managePermissionShouldAccessGlobalConfig() {
+        r.then(r -> {
+            final String USER = "user";
+            final String MANAGER = "manager";
+            r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
+            r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                    // Read access
+                    .grant(Jenkins.READ).everywhere().to(USER)
+
+                    // Read and Manage
+                    .grant(Jenkins.READ).everywhere().to(MANAGER)
+                    .grant(Jenkins.MANAGE).everywhere().to(MANAGER)
+            );
+
+            try (ACLContext c = ACL.as(User.getById(USER, true))) {
+                Collection<Descriptor> descriptors = Functions.getSortedDescriptorsForGlobalConfigUnclassified();
+                assertTrue("Global configuration should not be accessible to READ users", descriptors.size() == 0);
+            }
+            try (ACLContext c = ACL.as(User.getById(MANAGER, true))) {
+                Collection<Descriptor> descriptors = Functions.getSortedDescriptorsForGlobalConfigUnclassified();
+                Optional<Descriptor> found = descriptors.stream().filter(descriptor -> descriptor instanceof GlobalDefaultFlowDurabilityLevel.DescriptorImpl).findFirst();
+                assertTrue("Global configuration should be accessible to MANAGE users", found.isPresent());
+            }
         });
     }
 }


### PR DESCRIPTION
[JENKINS-62303](https://issues.jenkins-ci.org/browse/JENKINS-62303)

Allow Jenkins.MANAGE users to configure "Pipeline Default Speed/Durability Level" under Jenkins Global configuration.