### PR TITLE
[JENKINS-64438] Implement removeAll on FlowNode actions to support addOrReplaceAction.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.ObjectStreamException;
 import java.util.AbstractList;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -462,6 +463,15 @@ public abstract class FlowNode extends Actionable implements Saveable {
                 @Override
                 public int size() {
                     return actions.size();
+                }
+
+                @Override
+                public boolean removeAll(Collection<?> c) {
+                    boolean changed = actions.removeAll(c);
+                    if (changed) {
+                        persistSafe();
+                    }
+                    return changed;
                 }
         };
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/graph/FlowNodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/graph/FlowNodeTest.java
@@ -486,6 +486,7 @@ Action format:
         });
     }
 
+    @Issue("JENKINS-64438")
     @Test
     public void addOrReplaceActionWorks()  {
         rr.then(r -> {
@@ -613,4 +614,3 @@ Action format:
         }
     }
 }
-


### PR DESCRIPTION
This fixes https://issues.jenkins.io/browse/JENKINS-64438, which means that `addOrReplaceAction` on `FlowNode`s no longer explodes with a `UnsupportedOperationException`.