### PR TITLE
Use Java 7 versions of GZIPInputStream and GZIPOutputStream

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/log/ConsoleAnnotators.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/ConsoleAnnotators.java
@@ -24,8 +24,8 @@
 
 package org.jenkinsci.plugins.workflow.log;
 
-import com.jcraft.jzlib.GZIPInputStream;
-import com.jcraft.jzlib.GZIPOutputStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 import hudson.console.AnnotatedLargeText;
 import hudson.console.ConsoleAnnotationOutputStream;
 import hudson.console.ConsoleAnnotator;


### PR DESCRIPTION
See jenkinsci/cloudbees-folder-plugin#174 and jenkinsci/docker-build-step-plugin#75. [JZlib](https://github.com/ymnk/jzlib) has not been updated since 2013. Since then, [`GZIPInputStream`](https://docs.oracle.com/javase/8/docs/api/java/util/zip/GZIPInputStream.html) and [`GZIPOutputStream`](https://docs.oracle.com/javase/8/docs/api/java/util/zip/GZIPOutputStream.html) have been added to the Java 7 API, so it seems more prudent to use those implementations.