### PR TITLE
Migrate from `RestartableJenkinsRule` to `JenkinsSessionRule`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.16</version>
+        <version>4.19</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/visualization/table/FlowNodeViewColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/visualization/table/FlowNodeViewColumn.java
@@ -10,13 +10,13 @@ import org.kohsuke.stapler.export.Exported;
  * Extension point for adding a column to a table rendering of {@link FlowNode}s.
  *
  * <p>
- * This object must have the <tt>column.groovy</tt>. This view
+ * This object must have the {@code column.groovy}. This view
  * is called for each cell of this column. The {@link FlowNode} object
  * is passed in the "node" variable. The view should render
  * a {@code <td>} tag.
  *
  * <p>
- * This object may have an additional <tt>columnHeader.groovy</tt>. The default column header
+ * This object may have an additional {@code columnHeader.groovy}. The default column header
  * will render {@link #getColumnCaption()}.
  *
  * @author Kohsuke Kawaguchi

--- a/src/test/java/org/jenkinsci/plugins/workflow/flow/DurabilityBasicsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/flow/DurabilityBasicsTest.java
@@ -14,7 +14,7 @@ import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
@@ -28,42 +28,42 @@ import static org.junit.Assert.assertTrue;
 public class DurabilityBasicsTest {
 
     @Rule
-    public RestartableJenkinsRule r = new RestartableJenkinsRule();
+    public JenkinsSessionRule sessions = new JenkinsSessionRule();
 
     @Test
-    public void configRoundTrip() {
-        r.then(r -> {
-            GlobalDefaultFlowDurabilityLevel.DescriptorImpl level = r.jenkins.getExtensionList(GlobalDefaultFlowDurabilityLevel.DescriptorImpl.class).get(0);
+    public void configRoundTrip() throws Throwable {
+        sessions.then(j -> {
+            GlobalDefaultFlowDurabilityLevel.DescriptorImpl level = j.jenkins.getExtensionList(GlobalDefaultFlowDurabilityLevel.DescriptorImpl.class).get(0);
             level.setDurabilityHint(FlowDurabilityHint.PERFORMANCE_OPTIMIZED);
-            r.configRoundtrip();
+            j.configRoundtrip();
             Assert.assertEquals(FlowDurabilityHint.PERFORMANCE_OPTIMIZED, level.getDurabilityHint());
             level.setDurabilityHint(null);
-            r.configRoundtrip();
+            j.configRoundtrip();
             Assert.assertNull(level.getDurabilityHint());
 
             // Customize again so we can check for persistence
             level.setDurabilityHint(FlowDurabilityHint.PERFORMANCE_OPTIMIZED);
             Assert.assertEquals(FlowDurabilityHint.PERFORMANCE_OPTIMIZED, level.getDurabilityHint());
         });
-        r.then(r -> {
-            GlobalDefaultFlowDurabilityLevel.DescriptorImpl level = r.jenkins.getExtensionList(GlobalDefaultFlowDurabilityLevel.DescriptorImpl.class).get(0);
+        sessions.then(j -> {
+            GlobalDefaultFlowDurabilityLevel.DescriptorImpl level = j.jenkins.getExtensionList(GlobalDefaultFlowDurabilityLevel.DescriptorImpl.class).get(0);
             Assert.assertEquals(FlowDurabilityHint.PERFORMANCE_OPTIMIZED, level.getDurabilityHint());
         });
     }
 
     @Test
-    public void defaultHandling() {
-        r.then(r -> {
+    public void defaultHandling() throws Throwable {
+        sessions.then(j -> {
             Assert.assertEquals(GlobalDefaultFlowDurabilityLevel.SUGGESTED_DURABILITY_HINT, GlobalDefaultFlowDurabilityLevel.getDefaultDurabilityHint());
-            GlobalDefaultFlowDurabilityLevel.DescriptorImpl level = r.jenkins.getExtensionList(GlobalDefaultFlowDurabilityLevel.DescriptorImpl.class).get(0);
+            GlobalDefaultFlowDurabilityLevel.DescriptorImpl level = j.jenkins.getExtensionList(GlobalDefaultFlowDurabilityLevel.DescriptorImpl.class).get(0);
             level.setDurabilityHint(FlowDurabilityHint.PERFORMANCE_OPTIMIZED);
             Assert.assertEquals(FlowDurabilityHint.PERFORMANCE_OPTIMIZED, GlobalDefaultFlowDurabilityLevel.getDefaultDurabilityHint());
         });
     }
 
     @Test
-    public void managePermissionShouldAccessGlobalConfig() {
-        r.then(r -> {
+    public void managePermissionShouldAccessGlobalConfig() throws Throwable {
+        sessions.then(j -> {
             Permission jenkinsManage;
             try {
                 jenkinsManage = getJenkinsManage();
@@ -73,8 +73,8 @@ public class DurabilityBasicsTest {
             }
             final String USER = "user";
             final String MANAGER = "manager";
-            r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
-            r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+            j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+            j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
                     // Read access
                     .grant(Jenkins.READ).everywhere().to(USER)
 


### PR DESCRIPTION
We seem to be generally preferring `JenkinsSessionRule` to `RestartableJenkinsRule`. The main benefit to `JenkinsSessionRule` is that `#then` runs immediately, so it plays nicely with things like `@After.`