### PR TITLE
[JENKINS-65821] Fix race condition by using ConcurrentHashMap

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/graph/StandardGraphLookupView.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graph/StandardGraphLookupView.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Provides overall insight into the structure of a flow graph... but with limited visibility so we can change implementation.
@@ -25,10 +26,10 @@ public final class StandardGraphLookupView implements GraphLookupView, GraphList
     static final String INCOMPLETE = "";
 
     /** Map the blockStartNode to its endNode, to accellerate a range of operations */
-    HashMap<String, String> blockStartToEnd = new HashMap<>();
+    ConcurrentHashMap<String, String> blockStartToEnd = new ConcurrentHashMap<>();
 
     /** Map a node to its nearest enclosing block */
-    HashMap<String, String> nearestEnclosingBlock = new HashMap<>();
+    ConcurrentHashMap<String, String> nearestEnclosingBlock = new ConcurrentHashMap<>();
 
     public void clearCache() {
         blockStartToEnd.clear();


### PR DESCRIPTION
JENKINS-65821 described a race condition resulting in high cpu usage.  #153 attempted to address these using locking, but resulted in deadlocks. 

This change goes the other direction and attempts to address the issue using `ConcurrentHashMap` instead of `HashMap`.  

@twasyl

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
