### PR TITLE
Remove star imports and unused imports

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/MoreExecutors.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/MoreExecutors.java
@@ -19,8 +19,6 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
 
 /**
  * Factory and utility methods for {@link java.util.concurrent.Executor}, {@link ExecutorService},

--- a/src/test/java/org/jenkinsci/plugins/workflow/ArtifactManagerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/ArtifactManagerTest.java
@@ -24,6 +24,17 @@
 
 package org.jenkinsci.plugins.workflow;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
@@ -60,12 +71,10 @@ import jenkins.model.StandardArtifactManager;
 import jenkins.security.MasterToSlaveCallable;
 import jenkins.util.VirtualFile;
 import org.apache.commons.io.IOUtils;
-import static org.hamcrest.Matchers.*;
 import org.jenkinsci.plugins.workflow.flow.StashManager;
 import org.jenkinsci.test.acceptance.docker.Docker;
 import org.jenkinsci.test.acceptance.docker.DockerImage;
 import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
-import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/org/jenkinsci/plugins/workflow/actions/ErrorActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/actions/ErrorActionTest.java
@@ -24,8 +24,8 @@
 
 package org.jenkinsci.plugins.workflow.actions;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/org/jenkinsci/plugins/workflow/flow/DurabilityBasicsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/flow/DurabilityBasicsTest.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.workflow.flow;
 
-import hudson.ExtensionList;
 import hudson.Functions;
 import hudson.model.Descriptor;
 import hudson.model.User;

--- a/src/test/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListTest.java
@@ -24,6 +24,8 @@
 
 package org.jenkinsci.plugins.workflow.flow;
 
+import static org.junit.Assert.assertNotNull;
+
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.StringParameterDefinition;
@@ -35,9 +37,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.ClassRule;
 import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.Rule;
-import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.LoggerRule;

--- a/src/test/java/org/jenkinsci/plugins/workflow/graph/FlowNodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/graph/FlowNodeTest.java
@@ -54,9 +54,13 @@ import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.Test;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Rule;
 import org.junit.runners.model.Statement;

--- a/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScannerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScannerTest.java
@@ -50,9 +50,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-// Slightly dirty but it removes a ton of FlowTestUtils.* class qualifiers
-import static org.jenkinsci.plugins.workflow.graphanalysis.FlowTestUtils.*;
-
 /**
  * Tests for all the core parts of graph analysis except the ForkScanner, internals which is complex enough to merit its own tests
  * @author Sam Van Oort
@@ -148,31 +145,31 @@ public class FlowScannerTest {
         FlowNode firstEchoNode = exec.getNode("5");
         FlowExecution nullExecution = null;
 
-        Assert.assertEquals(firstEchoNode, linear.findFirstMatch(heads, Collections.EMPTY_LIST, MATCH_ECHO_STEP));
-        Assert.assertEquals(firstEchoNode, linear.findFirstMatch(heads, MATCH_ECHO_STEP));
-        Assert.assertEquals(firstEchoNode, linear.findFirstMatch(lastNode, MATCH_ECHO_STEP));
-        Assert.assertEquals(firstEchoNode, linear.findFirstMatch(exec, MATCH_ECHO_STEP));
-        Assert.assertNull(linear.findFirstMatch(nullColl, MATCH_ECHO_STEP));
-        Assert.assertNull(linear.findFirstMatch(Collections.EMPTY_SET, MATCH_ECHO_STEP));
-        Assert.assertNull(linear.findFirstMatch(nullNode, MATCH_ECHO_STEP));
-        Assert.assertNull(linear.findFirstMatch(nullExecution, MATCH_ECHO_STEP));
+        Assert.assertEquals(firstEchoNode, linear.findFirstMatch(heads, Collections.EMPTY_LIST, FlowTestUtils.MATCH_ECHO_STEP));
+        Assert.assertEquals(firstEchoNode, linear.findFirstMatch(heads, FlowTestUtils.MATCH_ECHO_STEP));
+        Assert.assertEquals(firstEchoNode, linear.findFirstMatch(lastNode, FlowTestUtils.MATCH_ECHO_STEP));
+        Assert.assertEquals(firstEchoNode, linear.findFirstMatch(exec, FlowTestUtils.MATCH_ECHO_STEP));
+        Assert.assertNull(linear.findFirstMatch(nullColl, FlowTestUtils.MATCH_ECHO_STEP));
+        Assert.assertNull(linear.findFirstMatch(Collections.EMPTY_SET, FlowTestUtils.MATCH_ECHO_STEP));
+        Assert.assertNull(linear.findFirstMatch(nullNode, FlowTestUtils.MATCH_ECHO_STEP));
+        Assert.assertNull(linear.findFirstMatch(nullExecution, FlowTestUtils.MATCH_ECHO_STEP));
 
 
         // Filtered nodes
-        assertNodeOrder("Filtered echo nodes", linear.filteredNodes(heads, MATCH_ECHO_STEP), 5, 4);
-        assertNodeOrder("Filtered echo nodes", linear.filteredNodes(heads, Collections.singleton(intermediateNode), MATCH_ECHO_STEP), 5);
+        FlowTestUtils.assertNodeOrder("Filtered echo nodes", linear.filteredNodes(heads, FlowTestUtils.MATCH_ECHO_STEP), 5, 4);
+        FlowTestUtils.assertNodeOrder("Filtered echo nodes", linear.filteredNodes(heads, Collections.singleton(intermediateNode), FlowTestUtils.MATCH_ECHO_STEP), 5);
         Assert.assertEquals(0, linear.filteredNodes(heads, null, (Predicate) Predicates.alwaysFalse()).size());
-        Assert.assertEquals(0, linear.filteredNodes(nullNode, MATCH_ECHO_STEP).size());
-        Assert.assertEquals(0, linear.filteredNodes(Collections.EMPTY_SET, MATCH_ECHO_STEP).size());
+        Assert.assertEquals(0, linear.filteredNodes(nullNode, FlowTestUtils.MATCH_ECHO_STEP).size());
+        Assert.assertEquals(0, linear.filteredNodes(Collections.EMPTY_SET, FlowTestUtils.MATCH_ECHO_STEP).size());
 
         // Same filter using the filterator
         linear.setup(heads);
         ArrayList<FlowNode> collected = new ArrayList<>();
-        Filterator<FlowNode> filt = linear.filter(MATCH_ECHO_STEP);
+        Filterator<FlowNode> filt = linear.filter(FlowTestUtils.MATCH_ECHO_STEP);
         while (filt.hasNext()) {
             collected.add(filt.next());
         }
-        assertNodeOrder("Filterator filtered echo nodes", collected, 5, 4);
+        FlowTestUtils.assertNodeOrder("Filterator filtered echo nodes", collected, 5, 4);
 
 
         // Visitor pattern tests
@@ -182,12 +179,12 @@ public class FlowScannerTest {
         visitor.reset();
 
         linear.visitAll(heads, visitor);
-        assertNodeOrder("Visiting all nodes", visitor.getVisited(), 6, 5, 4, 3, 2);
+        FlowTestUtils.assertNodeOrder("Visiting all nodes", visitor.getVisited(), 6, 5, 4, 3, 2);
 
         // And visiting with blacklist
         visitor.reset();
         linear.visitAll(heads, Collections.singleton(intermediateNode), visitor);
-        assertNodeOrder("Visiting all nodes with blacklist", visitor.getVisited(), 6, 5);
+        FlowTestUtils.assertNodeOrder("Visiting all nodes with blacklist", visitor.getVisited(), 6, 5);
 
         // Tests for edge cases of the various basic APIs
         linear.myNext = null;
@@ -238,12 +235,12 @@ public class FlowScannerTest {
         for (AbstractFlowScanner scan : scans) {
             System.out.println("Iteration test with scanner: " + scan.getClass());
             scan.setup(heads, null);
-            assertNodeOrder("Testing full scan for scanner " + scan.getClass(), scan, 6, 5, 4, 3, 2);
+            FlowTestUtils.assertNodeOrder("Testing full scan for scanner " + scan.getClass(), scan, 6, 5, 4, 3, 2);
             Assert.assertFalse(scan.hasNext());
 
             // Blacklist tests
             scan.setup(heads, Collections.singleton(exec.getNode("4")));
-            assertNodeOrder("Testing full scan for scanner " + scan.getClass(), scan, 6, 5);
+            FlowTestUtils.assertNodeOrder("Testing full scan for scanner " + scan.getClass(), scan, 6, 5);
             FlowNode f = scan.findFirstMatch(heads, Collections.singleton(exec.getNode("6")), Predicates.alwaysTrue());
             Assert.assertNull(f);
         }
@@ -282,9 +279,9 @@ public class FlowScannerTest {
         // Linear analysis
         LinearScanner linearScanner = new LinearScanner();
         linearScanner.setup(heads);
-        assertNodeOrder("Linear scan with block", linearScanner, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2);
+        FlowTestUtils.assertNodeOrder("Linear scan with block", linearScanner, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2);
         linearScanner.setup(exec.getNode("7"));
-        assertNodeOrder("Linear scan with block from middle ", linearScanner, 7, 6, 5, 4, 3, 2);
+        FlowTestUtils.assertNodeOrder("Linear scan with block from middle ", linearScanner, 7, 6, 5, 4, 3, 2);
 
         LinearBlockHoppingScanner linearBlockHoppingScanner = new LinearBlockHoppingScanner();
 
@@ -297,9 +294,9 @@ public class FlowScannerTest {
         linearBlockHoppingScanner.setup(heads);
         Assert.assertFalse(linearBlockHoppingScanner.hasNext());
         linearBlockHoppingScanner.setup(exec.getNode("8"));
-        assertNodeOrder("Hopping over one block", linearBlockHoppingScanner, 4, 3, 2);
+        FlowTestUtils.assertNodeOrder("Hopping over one block", linearBlockHoppingScanner, 4, 3, 2);
         linearBlockHoppingScanner.setup(exec.getNode("7"));
-        assertNodeOrder("Hopping over one block", linearBlockHoppingScanner, 7, 6, 5, 4, 3, 2);
+        FlowTestUtils.assertNodeOrder("Hopping over one block", linearBlockHoppingScanner, 7, 6, 5, 4, 3, 2);
 
         // Test the black list in combination with hopping
         linearBlockHoppingScanner.setup(exec.getNode("8"), Collections.singleton(exec.getNode("5")));
@@ -349,9 +346,9 @@ public class FlowScannerTest {
 
         AbstractFlowScanner scanner = new LinearScanner();
         scanner.setup(heads);
-        assertNodeOrder("Linear", scanner, 15, 14, 13, 9, 8, 6, 4, 3, 2);
+        FlowTestUtils.assertNodeOrder("Linear", scanner, 15, 14, 13, 9, 8, 6, 4, 3, 2);
         scanner.setup(heads, Collections.singleton(exec.getNode("9")));
-        assertNodeOrder("Linear", scanner, 15, 14, 13, 12, 11, 10, 7, 4, 3, 2);
+        FlowTestUtils.assertNodeOrder("Linear", scanner, 15, 14, 13, 12, 11, 10, 7, 4, 3, 2);
 
 
         // Depth first scanner and with blacklist
@@ -359,33 +356,33 @@ public class FlowScannerTest {
         scanner.setup(heads);
 
         // Compatibility test for ordering
-        assertNodeOrder("FlowGraphWalker", new FlowGraphWalker(exec), 15, 14, 13,
+        FlowTestUtils.assertNodeOrder("FlowGraphWalker", new FlowGraphWalker(exec), 15, 14, 13,
                 9, 8, 6, // Branch 1
                 4, 3, 2, // Before parallel
                 12, 11, 10, 7); // Branch 2
-        assertNodeOrder("Depth first", new FlowGraphWalker(exec), 15, 14, 13,
+        FlowTestUtils.assertNodeOrder("Depth first", new FlowGraphWalker(exec), 15, 14, 13,
                 9, 8, 6, // Branch 1
                 4, 3, 2, // Before parallel
                 12, 11, 10, 7); // Branch 2
         scanner.setup(heads, Collections.singleton(exec.getNode("9")));
-        assertNodeOrder("Linear", scanner, 15, 14, 13, 12, 11, 10, 7, 4, 3, 2);
+        FlowTestUtils.assertNodeOrder("Linear", scanner, 15, 14, 13, 12, 11, 10, 7, 4, 3, 2);
 
         scanner.setup(Arrays.asList(exec.getNode("9"), exec.getNode("12")));
-        assertNodeOrder("Depth-first scanner from inside parallels", scanner, 9, 8, 6, 4, 3, 2, 12, 11, 10, 7);
+        FlowTestUtils.assertNodeOrder("Depth-first scanner from inside parallels", scanner, 9, 8, 6, 4, 3, 2, 12, 11, 10, 7);
 
         // We're going to test the ForkScanner in more depth since this is its natural use
         scanner = new ForkScanner();
         scanner.setup(heads);
-        assertNodeOrder("ForkedScanner", scanner, 15, 14, 13,
+        FlowTestUtils.assertNodeOrder("ForkedScanner", scanner, 15, 14, 13,
                     12, 11, 10, 7,// One parallel
                     9, 8, 6, // other parallel
                 4, 3, 2); // end bit
         scanner.setup(heads, Collections.singleton(exec.getNode("9")));
-        assertNodeOrder("ForkedScanner", scanner, 15, 14, 13, 12, 11, 10, 7, 4, 3, 2);
+        FlowTestUtils.assertNodeOrder("ForkedScanner", scanner, 15, 14, 13, 12, 11, 10, 7, 4, 3, 2);
 
         // Test forkscanner midflow
         scanner.setup(exec.getNode("14"));
-        assertNodeOrder("ForkedScanner", scanner, 14, 13,
+        FlowTestUtils.assertNodeOrder("ForkedScanner", scanner, 14, 13,
                     12, 11, 10, 7, // Last parallel
                     9, 8, 6, // First parallel
                 4, 3, 2); // end bit
@@ -393,19 +390,19 @@ public class FlowScannerTest {
         // Test forkscanner inside a parallel
         List<FlowNode> startingPoints = Arrays.asList(exec.getNode("9"), exec.getNode("12"));
         scanner.setup(startingPoints);
-        assertNodeOrder("ForkedScanner", scanner, 9, 8, 6, 12, 11, 10, 7, 4, 3, 2);
+        FlowTestUtils.assertNodeOrder("ForkedScanner", scanner, 9, 8, 6, 12, 11, 10, 7, 4, 3, 2);
 
         startingPoints = Arrays.asList(exec.getNode("9"), exec.getNode("11"));
         scanner.setup(startingPoints);
-        assertNodeOrder("ForkedScanner", scanner, 9, 8, 6, 11, 10, 7, 4, 3, 2);
+        FlowTestUtils.assertNodeOrder("ForkedScanner", scanner, 9, 8, 6, 11, 10, 7, 4, 3, 2);
 
 
         // Filtering at different points within branches
         List<FlowNode> blackList = Arrays.asList(exec.getNode("6"), exec.getNode("7"));
-        Assert.assertEquals(4, scanner.filteredNodes(heads, blackList, MATCH_ECHO_STEP).size());
-        Assert.assertEquals(4, scanner.filteredNodes(heads, Collections.singletonList(exec.getNode("4")), MATCH_ECHO_STEP).size());
+        Assert.assertEquals(4, scanner.filteredNodes(heads, blackList, FlowTestUtils.MATCH_ECHO_STEP).size());
+        Assert.assertEquals(4, scanner.filteredNodes(heads, Collections.singletonList(exec.getNode("4")), FlowTestUtils.MATCH_ECHO_STEP).size());
         blackList = Arrays.asList(exec.getNode("6"), exec.getNode("10"));
-        Assert.assertEquals(3, scanner.filteredNodes(heads, blackList, MATCH_ECHO_STEP).size());
+        Assert.assertEquals(3, scanner.filteredNodes(heads, blackList, FlowTestUtils.MATCH_ECHO_STEP).size());
     }
 
     @Test
@@ -465,7 +462,7 @@ public class FlowScannerTest {
 
         // Basic test of DepthFirstScanner
         AbstractFlowScanner scanner = new DepthFirstScanner();
-        Collection<FlowNode> matches = scanner.filteredNodes(heads, null, MATCH_ECHO_STEP);
+        Collection<FlowNode> matches = scanner.filteredNodes(heads, null, FlowTestUtils.MATCH_ECHO_STEP);
         Assert.assertEquals(7, matches.size());
 
         scanner.setup(heads);
@@ -474,11 +471,11 @@ public class FlowScannerTest {
 
         // We're going to test the ForkScanner in more depth since this is its natural use
         scanner = new ForkScanner();
-        matches = scanner.filteredNodes(heads, null, MATCH_ECHO_STEP);
+        matches = scanner.filteredNodes(heads, null, FlowTestUtils.MATCH_ECHO_STEP);
         Assert.assertEquals(7, matches.size());
 
         heads = Arrays.asList(exec.getNode("20"), exec.getNode("17"), exec.getNode("9"));
-        matches = scanner.filteredNodes(heads, null, MATCH_ECHO_STEP);
+        matches = scanner.filteredNodes(heads, null, FlowTestUtils.MATCH_ECHO_STEP);
         Assert.assertEquals(6, matches.size()); // Commented out since temporarily failing
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScannerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScannerTest.java
@@ -58,9 +58,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-// Slightly dirty but it removes a ton of FlowTestUtils.* class qualifiers
-import static org.jenkinsci.plugins.workflow.graphanalysis.FlowTestUtils.*;
-
 /**
  * Tests for internals of ForkScanner
  */
@@ -362,7 +359,7 @@ public class ForkScannerTest {
         for (FlowNode f : mainBranch.visited) {
             nodeMap.put(f, mainBranch);
         }
-        assertNodeOrder("Visited nodes", mainBranch.visited, 9, 8, 6, 4, 3);
+        FlowTestUtils.assertNodeOrder("Visited nodes", mainBranch.visited, 9, 8, 6, 4, 3);
 
         // Branch 2
         sideBranch.add(BRANCH2_END);
@@ -372,16 +369,16 @@ public class ForkScannerTest {
         for (FlowNode f : sideBranch.visited) {
             nodeMap.put(f, sideBranch);
         }
-        assertNodeOrder("Visited nodes", sideBranch.visited, 12, 11, 10, 7);
+        FlowTestUtils.assertNodeOrder("Visited nodes", sideBranch.visited, 12, 11, 10, 7);
 
         ForkScanner.Fork forked = mainBranch.split(nodeMap, (BlockStartNode)exec.getNode("4"), sideBranch);
         ForkScanner.FlowSegment splitSegment = (ForkScanner.FlowSegment)nodeMap.get(BRANCH1_END); // New branch
         Assert.assertNull(splitSegment.after);
-        assertNodeOrder("Branch 1 split after fork", splitSegment.visited, 9, 8, 6);
+        FlowTestUtils.assertNodeOrder("Branch 1 split after fork", splitSegment.visited, 9, 8, 6);
 
         // Just the single node before the fork
         Assert.assertEquals(forked, mainBranch.after);
-        assertNodeOrder("Head of flow, pre-fork", mainBranch.visited, 3);
+        FlowTestUtils.assertNodeOrder("Head of flow, pre-fork", mainBranch.visited, 3);
 
         // Fork point
         Assert.assertEquals(forked, nodeMap.get(START_PARALLEL));
@@ -390,7 +387,7 @@ public class ForkScannerTest {
 
         // Branch 2
         Assert.assertEquals(sideBranch, nodeMap.get(BRANCH2_END));
-        assertNodeOrder("Branch 2", sideBranch.visited, 12, 11, 10, 7);
+        FlowTestUtils.assertNodeOrder("Branch 2", sideBranch.visited, 12, 11, 10, 7);
 
         // Test me where splitting right at a fork point, where we should have a fork with and main branch shoudl become following
         // Along with side branch (branch2)
@@ -410,9 +407,9 @@ public class ForkScannerTest {
         follows[0] = mainBranch;
         follows[1] = sideBranch;
         Assert.assertArrayEquals(follows, forked.following.toArray());
-        assertNodeOrder("Branch1", mainBranch.visited, 6);
+        FlowTestUtils.assertNodeOrder("Branch1", mainBranch.visited, 6);
         Assert.assertNull(mainBranch.after);
-        assertNodeOrder("Branch2", sideBranch.visited, 7);
+        FlowTestUtils.assertNodeOrder("Branch2", sideBranch.visited, 7);
         Assert.assertNull(sideBranch.after);
         Assert.assertEquals(forked, nodeMap.get(START_PARALLEL));
         Assert.assertEquals(mainBranch, nodeMap.get(exec.getNode("6")));

--- a/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/MemoryFlowChunkTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/MemoryFlowChunkTest.java
@@ -27,8 +27,8 @@ package org.jenkinsci.plugins.workflow.graphanalysis;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 
 public class MemoryFlowChunkTest {
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/log/FileLogStorageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/log/FileLogStorageTest.java
@@ -24,9 +24,10 @@
 
 package org.jenkinsci.plugins.workflow.log;
 
+import static org.junit.Assert.assertTrue;
+
 import hudson.model.TaskListener;
 import java.io.File;
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
@@ -24,6 +24,10 @@
 
 package org.jenkinsci.plugins.workflow.log;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertEquals;
+
 import hudson.console.AnnotatedLargeText;
 import hudson.console.HyperlinkNote;
 import hudson.model.Action;
@@ -51,7 +55,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.io.output.NullWriter;
 import org.apache.commons.io.output.WriterOutputStream;
-import static org.hamcrest.Matchers.*;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
@@ -59,7 +62,6 @@ import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;

--- a/src/test/java/org/jenkinsci/plugins/workflow/log/SpanCoalescerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/log/SpanCoalescerTest.java
@@ -24,10 +24,11 @@
 
 package org.jenkinsci.plugins.workflow.log;
 
+import static org.junit.Assert.assertEquals;
+
 import hudson.console.AnnotatedLargeText;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import static org.junit.Assert.*;
 import org.junit.Test;
 
 public class SpanCoalescerTest {


### PR DESCRIPTION
Replaces start imports with explicit imports and removes unused imports. The former allows us to migrate from the deprecated `org.junit.Assert.assertThat` to the non-deprecated `org.hamcrest.MatcherAssert.assertThat`.