### PR TITLE
[JENKINS-66826] Fix NPE in ErrorAction.isUnserializableException

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -75,6 +75,7 @@ public class ErrorAction implements PersistentAction {
         // contains references to the class loader for the Pipeline Script. Storing it leads
         // to memory leaks.
         if (error instanceof MissingPropertyException &&
+                ((MissingPropertyException)error).getType() != null &&
                 ((MissingPropertyException)error).getType().getClassLoader() instanceof GroovyClassLoader) {
             return true;
         }


### PR DESCRIPTION
Performing a non null check for MissingPropertyException's type in `isUnserializableException` to avoid the NPE. See: https://issues.jenkins.io/browse/JENKINS-66826
The NPE is causing the ErrorExtTest#testErrorExtNoGroovyNullPointerException to fail in `pipeline-stage-view` / `pipeline-rest-api`.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
