### PR TITLE
[JENKINS-67164] Call StepExecution.onResume directly from WorkflowRun.onLoad rather than via FlowExecutionList.ItemListenerImpl to ensure step resumption

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -10,6 +10,7 @@ import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.XmlFile;
 import hudson.init.Terminator;
+import hudson.model.listeners.ItemListener;
 import hudson.remoting.SingleLaneExecutorService;
 import hudson.util.CopyOnWriteList;
 import jenkins.model.Jenkins;
@@ -161,6 +162,21 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
             l = new FlowExecutionList();
         }
         return l;
+    }
+
+    /**
+     * When Jenkins starts up and everything is loaded, be sure to proactively resurrect
+     * all the ongoing {@link FlowExecution}s so that they start running again.
+     */
+    @Extension
+    public static class ItemListenerImpl extends ItemListener {
+        @Override
+        public void onLoaded() {
+            for (final FlowExecution e : FlowExecutionList.get()) {
+                // The call to FlowExecutionOwner.get in the implementation of iterator() is sufficent to load the Pipeline.
+                LOGGER.log(Level.FINE, "Eagerly loaded {0}", e);
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -5,7 +5,6 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.inject.Inject;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.XmlFile;
@@ -184,14 +183,11 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
      */
     @Extension
     public static class StepExecutionIteratorImpl extends StepExecutionIterator {
-        @Inject
-        FlowExecutionList list;
-
         @Override
         public ListenableFuture<?> apply(final Function<StepExecution, Void> f) {
             List<ListenableFuture<?>> all = new ArrayList<>();
 
-            for (FlowExecution e : list) {
+            for (FlowExecution e : FlowExecutionList.get()) {
                 ListenableFuture<List<StepExecution>> execs = e.getCurrentExecutions(false);
                 all.add(execs);
                 Futures.addCallback(execs,new FutureCallback<List<StepExecution>>() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -5,6 +5,8 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.XmlFile;
@@ -28,8 +30,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 
@@ -239,7 +239,7 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
     @Extension
     public static class ResumeStepExecutionListener extends FlowExecutionListener {
         @Override
-        public void onResumed(@Nonnull FlowExecution e) {
+        public void onResumed(@NonNull FlowExecution e) {
             Futures.addCallback(e.getCurrentExecutions(false), new FutureCallback<List<StepExecution>>() {
                 @Override
                 public void onSuccess(List<StepExecution> result) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -247,6 +247,13 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
             Futures.addCallback(e.getCurrentExecutions(false), new FutureCallback<List<StepExecution>>() {
                 @Override
                 public void onSuccess(List<StepExecution> result) {
+                    FlowExecutionList list = FlowExecutionList.get();
+                    FlowExecutionOwner owner = e.getOwner();
+                    if (!list.runningTasks.contains(owner)) {
+                        LOGGER.log(Level.WARNING, "Resuming {0}, which is missing from FlowExecutionList ({1}), so registering it now.",
+                                new Object[] {owner, list.runningTasks.getView()});
+                        list.register(owner);
+                    }
                     LOGGER.log(Level.FINE, "Will resume {0}", result);
                     for (StepExecution se : result) {
                         se.onResume();

--- a/src/test/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListTest.java
@@ -141,7 +141,7 @@ public class FlowExecutionListTest {
         });
     }
 
-    @Issue("TODO")
+    @Issue("JENKINS-67164")
     @Test public void resumeStepExecutions() throws Throwable {
         sessions.then(r -> {
             WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");


### PR DESCRIPTION
See [JENKINS-67164](https://issues.jenkins.io/browse/JENKINS-67164).

We have seen various reports of cases where a Pipeline resumes after a Jenkins restart and is occupying an executor slot, but the Pipeline in question appears to have already completed based on log output and it hangs forever after resuming. For example, see [JENKINS-50199](https://issues.jenkins.io/browse/JENKINS-50199) (fixed via hardening a different resumption code path) and [JENKINS-43587](https://issues.jenkins.io/browse/JENKINS-43587) (which maybe should not have been marked as resolved).

I was able to reproduce this issue when restoring Jenkins from a backup taken while Pipeline builds were in progress. The Pipelines in question were in the process of running a `SynchronousNonBlockingStepExecution` when the backup was taken, and that step should have failed when the Pipeline resumed and `FlowExecutionListener$ItemListenerImpl` called `StepExecution.onResume`, but this call never happened because the builds in question were not present in `org.jenkinsci.plugins.workflow.flow.FlowExecutionList.xml` on disk for some reason, so the execution just hung forever waiting for that step to complete. Additionally, the build logs indicated that the builds had already proceeded past this step, so it is not clear to me why `program.dat` was outdated. The Pipelines were using the standard `PERFORMANCE_OPTIMIZED` durability mode, and their `build.xml` files showed them as still in progress.

This PR attempts to harden the `StepExecution` resumption code by replacing `FlowExecutionListener.ItemListenerImpl` with a `FlowExecutionListener` that implements `onResumed`. `WorkflowRun.onLoad` directly calls `FlowExecutionListener.fireOnResumed` when it resumes in-progress Pipelines (happens automatically when `WorkflowRun.onLoad` is called), so it is guaranteed to be called for every Pipeline that resumes regardless of the stated of `FlowExecutionList`.

I will keep investigating to try to understand how this might happen in cases besides backups, since I think that this issue has been seen even when just restarting a controller normally.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
