### PR TITLE
[JENKINS-40161] Handle exceptions from `StepExecution.onResume`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -262,7 +262,11 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
                     }
                     LOGGER.log(Level.FINE, "Will resume {0}", result);
                     for (StepExecution se : result) {
-                        se.onResume();
+                        try {
+                            se.onResume();
+                        } catch (Throwable x) {
+                            se.getContext().onFailure(x);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Preparation for https://issues.jenkins.io/browse/JENKINS-40161. Cannot safely add `throws Exception` to the method signature, or start letting implementations throw exceptions, until most users have updated to get this code, so might as well do it now rather than later; at least will already handle `RuntimeException` and `Error`.

Not really related to #178, which just moved this block of code around without changing what it did when called.