### PR TITLE
[JENKINS-67351] Avoid deadlock when resuming Pipelines in some cases

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -10,6 +10,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.XmlFile;
+import hudson.init.InitMilestone;
 import hudson.init.Terminator;
 import hudson.model.listeners.ItemListener;
 import hudson.remoting.SingleLaneExecutorService;
@@ -48,6 +49,8 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
     private final CopyOnWriteList<FlowExecutionOwner> runningTasks = new CopyOnWriteList<>();
     private final SingleLaneExecutorService executor = new SingleLaneExecutorService(Timer.get());
     private XmlFile configFile;
+
+    private transient volatile boolean resumptionComplete;
 
     public FlowExecutionList() {
         load();
@@ -169,6 +172,17 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
     }
 
     /**
+     * Returns true if all executions that were present in this {@link FlowExecutionList} have been loaded and resumed.
+     *
+     * This takes place slightly after {@link InitMilestone#COMPLETED} is reached during Jenkins startup.
+     *
+     * Useful to avoid resuming Pipelines in contexts that may lead to deadlock.
+     */
+    public boolean isResumptionComplete() {
+        return resumptionComplete;
+    }
+
+    /**
      * When Jenkins starts up and everything is loaded, be sure to proactively resurrect
      * all the ongoing {@link FlowExecution}s so that they start running again.
      */
@@ -176,10 +190,12 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
     public static class ItemListenerImpl extends ItemListener {
         @Override
         public void onLoaded() {
-            for (final FlowExecution e : FlowExecutionList.get()) {
+            FlowExecutionList list = FlowExecutionList.get();
+            for (final FlowExecution e : list) {
                 // The call to FlowExecutionOwner.get in the implementation of iterator() is sufficent to load the Pipeline.
                 LOGGER.log(Level.FINE, "Eagerly loaded {0}", e);
             }
+            list.resumptionComplete = true;
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -15,8 +15,6 @@ import hudson.init.Terminator;
 import hudson.model.listeners.ItemListener;
 import hudson.remoting.SingleLaneExecutorService;
 import hudson.util.CopyOnWriteList;
-import hudson.util.DaemonThreadFactory;
-import hudson.util.NamingThreadFactory;;
 import jenkins.model.Jenkins;
 import jenkins.util.Timer;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -28,13 +26,10 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import jenkins.util.ContextResettingExecutorService;
 
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
@@ -298,10 +293,7 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
                     }
                 }
 
-            }, STEP_RESUMPTION_EXECUTOR_SERVICE); // We always hold RunMap and WorkflowRun locks here, so we resume steps on a different thread to avoid potential deadlocks. See JENKINS-67351.
+            }, Timer.get()); // We always hold RunMap and WorkflowRun locks here, so we resume steps on a different thread to avoid potential deadlocks. See JENKINS-67351.
         }
     }
-
-    // Using an unbounded thread pool to avoid potential deadlock as in JENKINS-25890. TODO: Unclear if this is actually necessary.
-    private static final ExecutorService STEP_RESUMPTION_EXECUTOR_SERVICE = new ContextResettingExecutorService(Executors.newCachedThreadPool(new NamingThreadFactory(new DaemonThreadFactory(), "FlowExecutionList$ResumeStepExecutionListener.onResumed")));
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -275,7 +275,7 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
                     }
                 }
 
-            }, MoreExecutors.directExecutor()); // TODO: Unclear if we need to run this asynchronously or if StepExecution.onResume has any particular thread requirements.
+            }, Timer.get()); // We always hold RunMap and WorkflowRun locks here, so we resume steps on a different thread to avoid potential deadlocks. See JENKINS-67351.
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -37,6 +37,7 @@ import java.util.logging.Logger;
 import jenkins.util.ContextResettingExecutorService;
 
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 
 /**
@@ -178,6 +179,7 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
      *
      * Useful to avoid resuming Pipelines in contexts that may lead to deadlock.
      */
+    @Restricted(Beta.class)
     public boolean isResumptionComplete() {
         return resumptionComplete;
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -14,6 +14,8 @@ import hudson.init.Terminator;
 import hudson.model.listeners.ItemListener;
 import hudson.remoting.SingleLaneExecutorService;
 import hudson.util.CopyOnWriteList;
+import hudson.util.DaemonThreadFactory;
+import hudson.util.NamingThreadFactory;;
 import jenkins.model.Jenkins;
 import jenkins.util.Timer;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -25,10 +27,13 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.util.ContextResettingExecutorService;
 
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -275,7 +280,10 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
                     }
                 }
 
-            }, Timer.get()); // We always hold RunMap and WorkflowRun locks here, so we resume steps on a different thread to avoid potential deadlocks. See JENKINS-67351.
+            }, STEP_RESUMPTION_EXECUTOR_SERVICE); // We always hold RunMap and WorkflowRun locks here, so we resume steps on a different thread to avoid potential deadlocks. See JENKINS-67351.
         }
     }
+
+    // Using an unbounded thread pool to avoid potential deadlock as in JENKINS-25890. TODO: Unclear if this is actually necessary.
+    private static final ExecutorService STEP_RESUMPTION_EXECUTOR_SERVICE = new ContextResettingExecutorService(Executors.newCachedThreadPool(new NamingThreadFactory(new DaemonThreadFactory(), "FlowExecutionList$ResumeStepExecutionListener.onResumed")));
 }


### PR DESCRIPTION
See [JENKINS-67351](https://issues.jenkins.io/browse/JENKINS-67351), #178, and https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/185.

The `RunMap` lock is always held when `WorkflowRun.onLoad` calls `FlowExecutionListener.fireResumed`, which means that any steps that need to acquire other locks in `StepExecution.onResume` (e.g. `ExecutorStepExecution.onResume` needs to acquire the queue lock to schedule a build) may trigger a deadlock with other code that also attempts to acquire the `RunMap` lock.

To prevent these issues, we use a new `ExecutorService` so that the `RunMap` lock is not held when resuming step executions.

This PR also introduces a new API that will be used to update https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/185 (will mark as ready for review once I have a PR up for that) to prevent Pipelines from being resumed before `FlowExecutionListener$ItemListenerImpl.onLoaded` has even had a chance to execute, which can lead to similar issues.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
