### PR TITLE
Revert fixes related to JENKINS-67351 and JENKINS-67164

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -5,7 +5,7 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.inject.Inject;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.XmlFile;
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.annotation.CheckForNull;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 
@@ -173,12 +172,9 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
      */
     @Extension
     public static class ItemListenerImpl extends ItemListener {
-        @Inject
-        FlowExecutionList list;
-
         @Override
         public void onLoaded() {
-            for (final FlowExecution e : list) {
+            for (final FlowExecution e : FlowExecutionList.get()) {
                 LOGGER.log(Level.FINE, "Eager loading {0}", e);
                 Futures.addCallback(e.getCurrentExecutions(false), new FutureCallback<List<StepExecution>>() {
                     @Override
@@ -207,14 +203,11 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
      */
     @Extension
     public static class StepExecutionIteratorImpl extends StepExecutionIterator {
-        @Inject
-        FlowExecutionList list;
-
         @Override
         public ListenableFuture<?> apply(final Function<StepExecution, Void> f) {
             List<ListenableFuture<?>> all = new ArrayList<>();
 
-            for (FlowExecution e : list) {
+            for (FlowExecution e : FlowExecutionList.get()) {
                 ListenableFuture<List<StepExecution>> execs = e.getCurrentExecutions(false);
                 all.add(execs);
                 Futures.addCallback(execs,new FutureCallback<List<StepExecution>>() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -258,11 +258,7 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
                     }
                     LOGGER.log(Level.FINE, "Will resume {0}", result);
                     for (StepExecution se : result) {
-                        try {
-                            se.onResume();
-                        } catch (Throwable x) {
-                            se.getContext().onFailure(x);
-                        }
+                        se.onResume();
                     }
                 }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -174,8 +174,10 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
     public static class ItemListenerImpl extends ItemListener {
         @Override
         public void onLoaded() {
-            for (final FlowExecution e : FlowExecutionList.get()) {
-                LOGGER.log(Level.FINE, "Eager loading {0}", e);
+            FlowExecutionList list = FlowExecutionList.get();
+            for (final FlowExecution e : list) {
+                // The call to FlowExecutionOwner.get in the implementation of iterator() is sufficent to load the Pipeline.
+                LOGGER.log(Level.FINE, "Eagerly loaded {0}", e);
                 Futures.addCallback(e.getCurrentExecutions(false), new FutureCallback<List<StepExecution>>() {
                     @Override
                     public void onSuccess(List<StepExecution> result) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -6,6 +6,7 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.XmlFile;
@@ -180,7 +181,7 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
                 LOGGER.log(Level.FINE, "Eagerly loaded {0}", e);
                 Futures.addCallback(e.getCurrentExecutions(false), new FutureCallback<List<StepExecution>>() {
                     @Override
-                    public void onSuccess(List<StepExecution> result) {
+                    public void onSuccess(@NonNull List<StepExecution> result) {
                         LOGGER.log(Level.FINE, "Will resume {0}", result);
                         for (StepExecution se : result) {
                             se.onResume();
@@ -188,7 +189,7 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
                     }
 
                     @Override
-                    public void onFailure(Throwable t) {
+                    public void onFailure(@NonNull Throwable t) {
                         if (t instanceof CancellationException) {
                             LOGGER.log(Level.FINE, "Cancelled load of " + e, t);
                         } else {
@@ -214,7 +215,7 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
                 all.add(execs);
                 Futures.addCallback(execs,new FutureCallback<List<StepExecution>>() {
                     @Override
-                    public void onSuccess(List<StepExecution> result) {
+                    public void onSuccess(@NonNull List<StepExecution> result) {
                         for (StepExecution e : result) {
                             try {
                                 f.apply(e);
@@ -225,7 +226,7 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
                     }
 
                     @Override
-                    public void onFailure(Throwable t) {
+                    public void onFailure(@NonNull Throwable t) {
                         LOGGER.log(Level.WARNING, null, t);
                     }
                 }, MoreExecutors.directExecutor());

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -160,6 +160,14 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
     }
 
     /**
+     * @deprecated Only exists for binary compatibility.
+     */
+    @Deprecated
+    public boolean isResumptionComplete() {
+        return false;
+    }
+
+    /**
      * When Jenkins starts up and everything is loaded, be sure to proactively resurrect
      * all the ongoing {@link FlowExecution}s so that they start running again.
      */

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -5,8 +5,7 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import com.google.inject.Inject;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.XmlFile;
@@ -30,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.CheckForNull;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 
@@ -165,11 +165,31 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
      */
     @Extension
     public static class ItemListenerImpl extends ItemListener {
+        @Inject
+        FlowExecutionList list;
+
         @Override
         public void onLoaded() {
-            for (final FlowExecution e : FlowExecutionList.get()) {
-                // The call to FlowExecutionOwner.get in the implementation of iterator() is sufficent to load the Pipeline.
-                LOGGER.log(Level.FINE, "Eagerly loaded {0}", e);
+            for (final FlowExecution e : list) {
+                LOGGER.log(Level.FINE, "Eager loading {0}", e);
+                Futures.addCallback(e.getCurrentExecutions(false), new FutureCallback<List<StepExecution>>() {
+                    @Override
+                    public void onSuccess(List<StepExecution> result) {
+                        LOGGER.log(Level.FINE, "Will resume {0}", result);
+                        for (StepExecution se : result) {
+                            se.onResume();
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        if (t instanceof CancellationException) {
+                            LOGGER.log(Level.FINE, "Cancelled load of " + e, t);
+                        } else {
+                            LOGGER.log(Level.WARNING, "Failed to load " + e, t);
+                        }
+                    }
+                }, MoreExecutors.directExecutor());
             }
         }
     }
@@ -179,16 +199,19 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
      */
     @Extension
     public static class StepExecutionIteratorImpl extends StepExecutionIterator {
+        @Inject
+        FlowExecutionList list;
+
         @Override
         public ListenableFuture<?> apply(final Function<StepExecution, Void> f) {
             List<ListenableFuture<?>> all = new ArrayList<>();
 
-            for (FlowExecution e : FlowExecutionList.get()) {
+            for (FlowExecution e : list) {
                 ListenableFuture<List<StepExecution>> execs = e.getCurrentExecutions(false);
                 all.add(execs);
                 Futures.addCallback(execs,new FutureCallback<List<StepExecution>>() {
                     @Override
-                    public void onSuccess(@NonNull List<StepExecution> result) {
+                    public void onSuccess(List<StepExecution> result) {
                         for (StepExecution e : result) {
                             try {
                                 f.apply(e);
@@ -199,7 +222,7 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
                     }
 
                     @Override
-                    public void onFailure(@NonNull Throwable t) {
+                    public void onFailure(Throwable t) {
                         LOGGER.log(Level.WARNING, null, t);
                     }
                 }, MoreExecutors.directExecutor());
@@ -224,54 +247,5 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
         SingleLaneExecutorService executor = get().executor;
         executor.shutdown();
         executor.awaitTermination(1, TimeUnit.MINUTES);
-    }
-
-    /**
-     * Whenever a Pipeline resumes, resume all incomplete steps in its {@link FlowExecution}.
-     *
-     * Called by {@code WorkflowRun.onLoad}, so guaranteed to run if a Pipeline resumes regardless of its presence in
-     * {@link FlowExecutionList}.
-     */
-    @Extension
-    public static class ResumeStepExecutionListener extends FlowExecutionListener {
-        @Override
-        public void onResumed(@NonNull FlowExecution e) {
-            Futures.addCallback(e.getCurrentExecutions(false), new FutureCallback<List<StepExecution>>() {
-                @Override
-                public void onSuccess(@NonNull List<StepExecution> result) {
-                    if (e.isComplete()) {
-                        // WorkflowRun.onLoad will not fire onResumed if the serialized execution was already
-                        // complete when loaded, but right now (at least for workflow-cps), the execution resumes
-                        // asynchronously before WorkflowRun.onLoad completes, so it is possible that the execution
-                        // finishes before onResumed gets called.
-                        // That said, there is nothing to prevent the execution from completing right after we check
-                        // isComplete. If we want to fully prevent that, we would need to delay actual execution
-                        // resumption until WorkflowRun.onLoad completes or add some form of synchronization.
-                        return;
-                    }
-                    FlowExecutionList list = FlowExecutionList.get();
-                    FlowExecutionOwner owner = e.getOwner();
-                    if (!list.runningTasks.contains(owner)) {
-                        LOGGER.log(Level.WARNING, "Resuming {0}, which is missing from FlowExecutionList ({1}), so registering it now.",
-                                new Object[] {owner, list.runningTasks.getView()});
-                        list.register(owner);
-                    }
-                    LOGGER.log(Level.FINE, "Will resume {0}", result);
-                    for (StepExecution se : result) {
-                        se.onResume();
-                    }
-                }
-
-                @Override
-                public void onFailure(@NonNull Throwable t) {
-                    if (t instanceof CancellationException) {
-                        LOGGER.log(Level.FINE, "Cancelled load of " + e, t);
-                    } else {
-                        LOGGER.log(Level.WARNING, "Failed to load " + e, t);
-                    }
-                }
-
-            }, MoreExecutors.directExecutor()); // TODO: Unclear if we need to run this asynchronously or if StepExecution.onResume has any particular thread requirements.
-        }
     }
 }


### PR DESCRIPTION
Reverts #188, #187, and #178 due to problems in https://github.com/jenkinsci/workflow-api-plugin/pull/188 (see https://github.com/jenkinsci/workflow-api-plugin/pull/188#issuecomment-1013382364) which have no obvious fix.

The `FlowExecutionList.isResumptionComplete` API from #188 is preserved to avoid binary compatibility issues with `workflow-durable-task-step` prior to https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/197.

These fixes were generally expected only to apply to uncommon scenarios related to disaster recovery, so I think it is ok to revert them for now.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
