### PR TITLE
Utilize modern build status

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.249.1</jenkins.version>
+        <jenkins.version>2.277.4</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
@@ -73,7 +73,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.249.x</artifactId>
+                <artifactId>bom-2.277.x</artifactId>
                 <version>984.vb5eaac999a7e</version>
                 <scope>import</scope>
                 <type>pom</type>

--- a/src/main/resources/lib/flow/nodeCaption.jelly
+++ b/src/main/resources/lib/flow/nodeCaption.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout">
   <st:documentation>
     Generate a caption for the main panel that renders the status of the flow node.
 
@@ -31,7 +31,7 @@ THE SOFTWARE.
   </st:documentation>
 
 	<h1 class="build-caption page-headline">
-	  <img class="build-caption-status-icon" src="${imagesURL}/48x48/${node.iconColor.image}" width="48" height="48"
+	  <l:icon class="${node.iconColor.iconClassName} icon-xlg"
          alt="${node.iconColor.description}" tooltip="${node.iconColor.description}" />
 	  <d:invokeBody />
 	</h1>


### PR DESCRIPTION
The change proposed utilizes the modern build icons, like they are used in other parts of Jenkins.
The pom change bumps the baseline to the LTS version the change has been introduced in.

Before:
![](https://i.imgur.com/gCU2eht.png)

My proposed change:
![](https://i.imgur.com/rBk8Zgs.png)

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue