### PR TITLE
Update `<select>` config appearance 

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel/global.jelly
@@ -2,16 +2,17 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:section title="Pipeline Speed/Durability Settings">
         <f:entry title="${%Pipeline Default Speed/Durability Level}" field="durabilityHint">
-            <select class="setting-input" name="durabilityHint">
-                <f:option value="null" selected="${instance[field] == null}">None: use pipeline default (<j:out value="${descriptor.suggestedDurabilityHint.name()}" />)</f:option>
-                <j:forEach var="it" items="${descriptor.durabilityHintValues}">
-                    <j:set var="optionBody" encode="false">${it.description}</j:set>
-                    <option value="${it.name()}"
-                            selected="${(it==instance[field]) ? 'true':null}"
-                            tooltip="${it.tooltip}"><j:out value="${optionBody}"/></option>
-                </j:forEach>
-            </select>
+            <div class="jenkins-select">
+                <select class="jenkins-select__input" name="durabilityHint">
+                    <f:option value="null" selected="${instance[field] == null}">None: use pipeline default (<j:out value="${descriptor.suggestedDurabilityHint.name()}" />)</f:option>
+                    <j:forEach var="it" items="${descriptor.durabilityHintValues}">
+                        <j:set var="optionBody" encode="false">${it.description}</j:set>
+                        <option value="${it.name()}"
+                                selected="${(it==instance[field]) ? 'true':null}"
+                                tooltip="${it.tooltip}"><j:out value="${optionBody}"/></option>
+                    </j:forEach>
+                </select>
+            </div>
         </f:entry>
     </f:section>
-    <br/><br/>
 </j:jelly>


### PR DESCRIPTION
This PR updates the `<select>` config appearance to use the new classes introduced in [Jenkins #5923](https://github.com/jenkinsci/jenkins/pull/5923).

**Before**
<img width="981" alt="image" src="https://user-images.githubusercontent.com/43062514/154872514-d60eb627-5b30-43bf-9ae5-4d4391f0e223.png">

**After**
<img width="973" alt="image" src="https://user-images.githubusercontent.com/43062514/154872619-f0d46ef0-6603-418b-97e7-78f0d69bdb79.png">

Just a heads up that the pre-existing `tooltip` attribute seemingly doesn't do anything on `<option>`, tried it on Safari and Chrome.

Cheers.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
