### PR TITLE
Replace handbuilt html with jelly for flow durability

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel.java
@@ -56,7 +56,7 @@ public class GlobalDefaultFlowDurabilityLevel extends AbstractDescribableImpl<Gl
             FlowDurabilityHint flowDurabilityHint = Arrays.stream(FlowDurabilityHint.values())
                     .filter(f -> f.name().equals(durabilityHint))
                     .findFirst()
-                    .orElse(FlowDurabilityHint.MAX_SURVIVABILITY);
+                    .orElse(GlobalDefaultFlowDurabilityLevel.SUGGESTED_DURABILITY_HINT);
 
             return FormValidation.ok(flowDurabilityHint.getTooltip());
         }
@@ -79,20 +79,12 @@ public class GlobalDefaultFlowDurabilityLevel extends AbstractDescribableImpl<Gl
             return true;
         }
 
-        public static FlowDurabilityHint getSuggestedDurabilityHint() {
-            return GlobalDefaultFlowDurabilityLevel.SUGGESTED_DURABILITY_HINT;
-        }
-
-        public static FlowDurabilityHint[] getDurabilityHintValues() {
-            return FlowDurabilityHint.values();
-        }
-
         public ListBoxModel doFillDurabilityHintItems() {
             ListBoxModel options = new ListBoxModel();
 
-            options.add("None: use pipeline default (" + getSuggestedDurabilityHint().name() + ")", "null");
+            options.add("None: use pipeline default (" + GlobalDefaultFlowDurabilityLevel.SUGGESTED_DURABILITY_HINT.name() + ")", "null");
 
-            List<ListBoxModel.Option> mappedOptions = Arrays.stream(getDurabilityHintValues())
+            List<ListBoxModel.Option> mappedOptions = Arrays.stream(FlowDurabilityHint.values())
                     .map(hint -> new ListBoxModel.Option(hint.getDescription(), hint.name()))
                     .collect(Collectors.toList());
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel.java
@@ -5,7 +5,6 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.security.Permission;
 import hudson.util.ListBoxModel;
-import hudson.util.ReflectionUtils;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel.java
@@ -4,12 +4,14 @@ import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.security.Permission;
+import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
+import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -48,6 +50,15 @@ public class GlobalDefaultFlowDurabilityLevel extends AbstractDescribableImpl<Gl
         public void setDurabilityHint(FlowDurabilityHint hint){
             this.durabilityHint = hint;
             save();
+        }
+
+        public FormValidation doCheckDurabilityHint(@QueryParameter("durabilityHint") String durabilityHint) {
+            FlowDurabilityHint flowDurabilityHint = Arrays.stream(FlowDurabilityHint.values())
+                    .filter(f -> f.name().equals(durabilityHint))
+                    .findFirst()
+                    .orElse(FlowDurabilityHint.MAX_SURVIVABILITY);
+
+            return FormValidation.ok(flowDurabilityHint.getTooltip());
         }
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel.java
@@ -4,7 +4,11 @@ import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.security.Permission;
+import hudson.util.ListBoxModel;
 import hudson.util.ReflectionUtils;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.StaplerRequest;
@@ -72,6 +76,20 @@ public class GlobalDefaultFlowDurabilityLevel extends AbstractDescribableImpl<Gl
 
         public static FlowDurabilityHint[] getDurabilityHintValues() {
             return FlowDurabilityHint.values();
+        }
+
+        public ListBoxModel doFillDurabilityHintItems() {
+            ListBoxModel options = new ListBoxModel();
+
+            options.add("None: use pipeline default (" + getSuggestedDurabilityHint().name() + ")", "null");
+
+            List<ListBoxModel.Option> mappedOptions = Arrays.stream(getDurabilityHintValues())
+                    .map(hint -> new ListBoxModel.Option(hint.getDescription(), hint.name()))
+                    .collect(Collectors.toList());
+
+            options.addAll(mappedOptions);
+
+            return options;
         }
 
         @NonNull

--- a/src/main/resources/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel/global.jelly
@@ -2,15 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:section title="Pipeline Speed/Durability Settings">
         <f:entry title="${%Pipeline Default Speed/Durability Level}" field="durabilityHint">
-            <select class="setting-input" name="durabilityHint">
-                <f:option value="null" selected="${instance[field] == null}">None: use pipeline default (<j:out value="${descriptor.suggestedDurabilityHint.name()}" />)</f:option>
-                <j:forEach var="it" items="${descriptor.durabilityHintValues}">
-                    <j:set var="optionBody" encode="false">${it.description}</j:set>
-                    <option value="${it.name()}"
-                            selected="${(it==instance[field]) ? 'true':null}"
-                            tooltip="${it.tooltip}"><j:out value="${optionBody}"/></option>
-                </j:forEach>
-            </select>
+            <f:select />
         </f:entry>
     </f:section>
     <br/><br/>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel/global.jelly
@@ -1,9 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:section title="Pipeline Speed/Durability Settings">
-        <f:entry title="${%Pipeline Default Speed/Durability Level}" field="durabilityHint">
+    <f:section title="${%Pipeline Speed / Durability}">
+        <f:entry title="${%Default Speed / Durability Level}" field="durabilityHint">
             <f:select />
         </f:entry>
     </f:section>
-    <br/><br/>
 </j:jelly>


### PR DESCRIPTION
The downside I can see with this is that tooltips are no longer shown.

But tooltips on a drop down are really weird. So not sure if it's the worst idea to get rid of this.

alternative to https://github.com/jenkinsci/workflow-api-plugin/pull/202