### PR TITLE
[JENKINS-40161] Handle exceptions from `StepExecution.onResume`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -184,7 +184,11 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
                     public void onSuccess(@NonNull List<StepExecution> result) {
                         LOGGER.log(Level.FINE, "Will resume {0}", result);
                         for (StepExecution se : result) {
-                            se.onResume();
+                            try {
+                                se.onResume();
+                            } catch (Throwable x) {
+                                se.getContext().onFailure(x);
+                            }
                         }
                     }
 


### PR DESCRIPTION
Reapplying #187, which happened to have gotten caught up in some barely related flow control changes and reverted in #198.
