### PR TITLE
[JENKINS-67164] Call `StepExecution.onResume` in response to `WorkflowRun.onLoad` not `FlowExecutionList.ItemListenerImpl`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecution.java
@@ -322,4 +322,12 @@ public abstract class FlowExecution implements FlowActionStorage, GraphLookupVie
     protected void notifyShutdown() {
         // Default is no-op
     }
+
+    /**
+     * Called after a restart and any attempts at {@link StepExecution#onResume} have completed.
+     * This is a signal that it is safe to resume program execution.
+     * By default, does nothing.
+     */
+    protected void afterStepExecutionsResumed() {}
+
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -361,7 +361,7 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
                 StepExecution exec = entry.getValue();
                 processing.add(n);
                 // Strictly speaking threadPoolForRemoting should be used for agent communications.
-                // In practice the onResume impl known to block is in ExecutorStepExecution.
+                // In practice the only onResume impl known to block is in ExecutorStepExecution.
                 // Avoid jenkins.util.Timer since it is capped at 10 threads and should not be used for long tasks.
                 Computer.threadPoolForRemoting.submit(() -> {
                     LOGGER.fine(() -> "About to resume " + n + " ~ " + exec);

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListener.java
@@ -62,6 +62,7 @@ public abstract class FlowExecutionListener implements ExtensionPoint {
      * Fires the {@link #onCreated(FlowExecution)} event.
      */
     public static void fireCreated(@NonNull FlowExecution execution) {
+        // TODO Jenkins 2.325+ use Listeners.notify
         for (FlowExecutionListener listener : ExtensionList.lookup(FlowExecutionListener.class)) {
             listener.onCreated(execution);
         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListTest.java
@@ -24,17 +24,35 @@
 
 package org.jenkinsci.plugins.workflow.flow;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertNotNull;
 
+import hudson.AbortException;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Result;
 import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
+import hudson.model.TaskListener;
 import hudson.model.queue.QueueTaskFuture;
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Supplier;
 import java.util.logging.Level;
+import org.hamcrest.Matcher;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.Rule;
@@ -42,6 +60,8 @@ import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.JenkinsSessionRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 public class FlowExecutionListTest {
 
@@ -77,6 +97,115 @@ public class FlowExecutionListTest {
                 j.assertBuildStatusSuccess(j.waitForCompletion(b2));
                 j.assertBuildStatusSuccess(j.waitForCompletion(b3));
         });
+    }
+
+    @Test public void forceLoadRunningExecutionsAfterRestart() throws Throwable {
+        logging.capture(50);
+        sessions.then(r -> {
+            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition("semaphore('wait')", true));
+            WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+            SemaphoreStep.waitForStart("wait/1", b);
+        });
+        sessions.then(r -> {
+            /*
+            Make sure that the build gets loaded automatically by FlowExecutionList$ItemListenerImpl before we load it explictly.
+            Expected call stack for resuming a Pipelines and its steps:
+                at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$ResumeStepExecutionListener$1.onSuccess(FlowExecutionList.java:250)
+                at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$ResumeStepExecutionListener$1.onSuccess(FlowExecutionList.java:247)
+                at com.google.common.util.concurrent.Futures$6.run(Futures.java:975)
+                at org.jenkinsci.plugins.workflow.flow.DirectExecutor.execute(DirectExecutor.java:33)
+                ... Guava Futures API internals ...
+                at com.google.common.util.concurrent.Futures.addCallback(Futures.java:985)
+                at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$ResumeStepExecutionListener.onResumed(FlowExecutionList.java:247)
+                at org.jenkinsci.plugins.workflow.flow.FlowExecutionListener.fireResumed(FlowExecutionListener.java:84)
+                at org.jenkinsci.plugins.workflow.job.WorkflowRun.onLoad(WorkflowRun.java:528)
+                at hudson.model.RunMap.retrieve(RunMap.java:225)
+                ... RunMap internals ...
+                at hudson.model.RunMap.getById(RunMap.java:205)
+                at org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.run(WorkflowRun.java:937)
+                at org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.get(WorkflowRun.java:948)
+                at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$1.computeNext(FlowExecutionList.java:65)
+                at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$1.computeNext(FlowExecutionList.java:57)
+                at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:143)
+                at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:138)
+                at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$ItemListenerImpl.onLoaded(FlowExecutionList.java:175)
+                at jenkins.model.Jenkins.<init>(Jenkins.java:1019)
+            */
+            waitFor(logging::getMessages, hasItem(containsString("Will resume [org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep")));
+            WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
+            SemaphoreStep.success("wait/1", null);
+            WorkflowRun b = p.getBuildByNumber(1);
+            r.waitForCompletion(b);
+            r.assertBuildStatus(Result.SUCCESS, b);
+        });
+    }
+
+    @Issue("JENKINS-67164")
+    @Test public void resumeStepExecutions() throws Throwable {
+        sessions.then(r -> {
+            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition("noResume()", true));
+            WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+            r.waitForMessage("Starting non-resumable step", b);
+            // TODO: Unclear how this might happen in practice.
+            FlowExecutionList.get().unregister(b.asFlowExecutionOwner());
+        });
+        sessions.then(r -> {
+            WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
+            WorkflowRun b = p.getBuildByNumber(1);
+            r.waitForCompletion(b);
+            r.assertBuildStatus(Result.FAILURE, b);
+            r.assertLogContains("Unable to resume NonResumableStep", b);
+        });
+    }
+
+    public static class NonResumableStep extends Step implements Serializable {
+        public static final long serialVersionUID = 1L;
+        @DataBoundConstructor
+        public NonResumableStep() { }
+        @Override
+        public StepExecution start(StepContext sc) {
+            return new ExecutionImpl(sc);
+        }
+
+        private static class ExecutionImpl extends StepExecution implements Serializable {
+            public static final long serialVersionUID = 1L;
+            private ExecutionImpl(StepContext sc) {
+                super(sc);
+            }
+            @Override
+            public boolean start() throws Exception {
+                getContext().get(TaskListener.class).getLogger().println("Starting non-resumable step");
+                return false;
+            }
+            @Override
+            public void onResume() {
+                getContext().onFailure(new AbortException("Unable to resume NonResumableStep"));
+            }
+        }
+
+        @TestExtension public static class DescriptorImpl extends StepDescriptor {
+            @Override
+            public Set<? extends Class<?>> getRequiredContext() {
+                return Collections.singleton(TaskListener.class);
+            }
+            @Override
+            public String getFunctionName() {
+                return "noResume";
+            }
+        }
+    }
+
+    /**
+     * Wait up to 5 seconds for the given supplier to return a matching value.
+     */
+    private static <T> void waitFor(Supplier<T> valueSupplier, Matcher<T> matcher) throws InterruptedException {
+        Instant end = Instant.now().plus(Duration.ofSeconds(5));
+        while (!matcher.matches(valueSupplier.get()) && Instant.now().isBefore(end)) {
+            Thread.sleep(100L);
+        }
+        assertThat("Matcher should have matched after 5s", valueSupplier.get(), matcher);
     }
 
 }


### PR DESCRIPTION
[JENKINS-67164](https://issues.jenkins.io/browse/JENKINS-67164): Reapplies #178 and its amendment #188, reverting the reversion #198.

Fixes the problem identified in `SSHAgentStepWorkflowTest.sshAgentAvailableAfterRestart` whereby a `sh` step began running while an `sshagent` step was still in the middle of an `onResume`, by introducing a `FlowExecution.afterStepExecutionsResumed` hook which `CpsFlowExecution` will implement to unpause the program near the end of `WorkflowRun.onLoad`, rather than unpausing immediately upon deserializing `program.dat`.

Seems to offer a nicer way to implement the `ExecutorPickle` replacement portion of https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180, by letting `ExecutorStepExecution.onResume` wait for an agent to reconnect before resuming progran execution. Compared to `ExecutorPickle` the advantage is that if there is in fact a timeout, rather than marking the entire program as a failure to load, the `node` step can throw a proper Groovy-level exception which can be handled gracefully.

A matching PR to `workflow-cps-plugin` is needed to avoid the class of regression seen with `sshagent`. ~I would like to run some integration tests in advance.~ https://github.com/jenkinsci/bom/pull/1122#issuecomment-1124901390