### PR TITLE
Use proper CSS class for build status icon

### DIFF
--- a/src/main/resources/lib/flow/nodeCaption.jelly
+++ b/src/main/resources/lib/flow/nodeCaption.jelly
@@ -33,6 +33,8 @@ THE SOFTWARE.
 	<h1 class="build-caption page-headline">
 	  <l:icon class="${node.iconColor.iconClassName} icon-xlg"
          alt="${node.iconColor.description}" tooltip="${node.iconColor.description}" />
-	  <d:invokeBody />
+        <span class="jenkins-icon-adjacent">
+            <d:invokeBody trim="true"/>
+        </span>
 	</h1>
 </j:jelly>


### PR DESCRIPTION
As opposed to other locations in Jenkins, the build status isn't wrapped in the proper class, which leads to a false rendering:
![](https://i.imgur.com/eFnwvIa.png)

The change proposed takes care of that and ensures the format is no longer out of style:
![](https://i.imgur.com/7rWRV4r.png)

cc @car-roll 