### PR TITLE
Require 2.332.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.289.3</jenkins.version>
+        <jenkins.version>2.332.1</jenkins.version>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -72,7 +72,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.289.x</artifactId>
+                <artifactId>bom-2.332.x</artifactId>
                 <version>1382.v7d694476f340</version>
                 <scope>import</scope>
                 <type>pom</type>


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-cps-plugin/pull/534 requires 2.332.x so avoid offering #221 to 2.319.x- users. Should probably also block https://github.com/jenkinsci/workflow-api-plugin/releases/tag/1162.va_1e49062a_00e from the UC. (Noticed this in https://github.com/jenkinsci/bom/pull/1187.)