### PR TITLE
Diagnosis for `NoSuchElementException` from `ForkScanner.setHeads`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/ForkScanner.java
@@ -439,6 +439,10 @@ public class ForkScanner extends AbstractFlowScanner {
             }
         }
 
+        if (parallelForks.isEmpty()) {
+            throw new IllegalStateException("No least common ancestor found from " + heads);
+        }
+
         // If we hit issues with the ordering of blocks by depth, apply a sorting to the parallels by depth
         return convertForksToBlockStarts(parallelForks);
     }
@@ -450,7 +454,6 @@ public class ForkScanner extends AbstractFlowScanner {
                 headIds.add(f.getId());
             }
             parallelBlockStartStack = leastCommonAncestor(new LinkedHashSet<>(heads));
-            assert parallelBlockStartStack.size() > 0;
             currentParallelStart = parallelBlockStartStack.pop();
             currentParallelStartNode = currentParallelStart.forkStart;
             myCurrent = currentParallelStart.unvisited.pop();


### PR DESCRIPTION
A pipeline (`unified-release` for @cloudbees employees) had a function like

```groovy
void skipStage(def stage) {
    println "Skip stage ${stage}"
    org.jenkinsci.plugins.pipeline.modeldefinition.Utils.markStageSkippedForConditional(stage)
}
```

which I observed to throw an error on one occasion (no idea if reproducible)

```
java.util.NoSuchElementException
	at java.base/java.util.ArrayDeque.removeFirst(ArrayDeque.java:363)
	at java.base/java.util.ArrayDeque.pop(ArrayDeque.java:594)
	at org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner.setHeads(ForkScanner.java:456)
	at org.jenkinsci.plugins.workflow.graphanalysis.AbstractFlowScanner.setup(AbstractFlowScanner.java:140)
	at org.jenkinsci.plugins.workflow.graphanalysis.AbstractFlowScanner.findFirstMatch(AbstractFlowScanner.java:250)
	at …
	at org.jenkinsci.plugins.pipeline.modeldefinition.Utils.findStageFlowNodes(Utils.groovy:238)
	at org.jenkinsci.plugins.pipeline.modeldefinition.Utils.findStageFlowNodes(Utils.groovy)
	at org.jenkinsci.plugins.pipeline.modeldefinition.Utils$findStageFlowNodes$9.callStatic(Unknown Source)
	at org.jenkinsci.plugins.pipeline.modeldefinition.Utils.markStageWithTag(Utils.groovy:310)
	at org.jenkinsci.plugins.pipeline.modeldefinition.Utils$markStageWithTag$8.callStatic(Unknown Source)
	at org.jenkinsci.plugins.pipeline.modeldefinition.Utils.markStageSkippedForConditional(Utils.groovy:400)
	at org.jenkinsci.plugins.pipeline.modeldefinition.Utils$markStageSkippedForConditional$15.callStatic(Unknown Source)
	at …
	at WorkflowScript.skipStage(WorkflowScript:…)
	at …
```

It seems the intention was for the return value of `leastCommonAncestor` to be nonempty, but the `assert` was not run in production and there is no diagnostic information here.
