### PR TITLE
Require Java 11 and update parent POM, BOM, and minimum supported Jenkins version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-  [ platform: "linux", jdk: "8" ],
-  [ platform: "windows", jdk: "8" ],
-  [ platform: "linux", jdk: "11" ]
+  [ platform: "linux", jdk: "17" ],
+  [ platform: "windows", jdk: "11" ]
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plugin</artifactId>
-      <version>4.48</version>
+      <version>4.53</version>
       <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -63,7 +63,7 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.332.1</jenkins.version>
+        <jenkins.version>2.361.4</jenkins.version>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -72,8 +72,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.332.x</artifactId>
-                <version>1466.v85a_616ea_b_87c</version>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>1763.v092b_8980a_f5e</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/SimpleChunkVisitor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/graphanalysis/SimpleChunkVisitor.java
@@ -68,7 +68,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  *   have (such as the start of another parallel).</em>
  *
  * <p>Implementations get to decide how to use and handle chunks, and should be stateful.
- * <h3>At a minimum they should handle:</h3>
+ * <p><strong>At a minimum they should handle:</strong>
  * <ul>
  *     <li>Cases where there is no enclosing chunk (no start/end found, or outside a chunk)</li>
  *     <li>Cases where there is no chunk end to match the start, because we haven't finished running a block</li>

--- a/src/test/java/org/jenkinsci/plugins/workflow/log/FileLogStorageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/log/FileLogStorageTest.java
@@ -52,7 +52,7 @@ public class FileLogStorageTest extends LogStorageTestBase {
         overall.getLogger().println("stuff");
         close(overall);
         assertTrue(new File(log + "-index").delete());
-        assertOverallLog(0, "stuff\n", true);
+        assertOverallLog(0, lines("stuff"), true);
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
@@ -346,7 +346,7 @@ public abstract class LogStorageTestBase {
     /**
      * Concatenate the given lines after interspersing system-dependent line separators between them and adding a final line separator.
      */
-    private String lines(CharSequence... lines) {
+    protected String lines(CharSequence... lines) {
         return String.join(System.lineSeparator(), lines) + System.lineSeparator();
     }
 


### PR DESCRIPTION
Replaces #268 and #272.

(I do not particularly care about releasing these changes; I only want to see if `FileLogStorageTest` passes on Windows when running Java 11.)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
