### PR TITLE
Improve consistency of `ErrorAction.findOrigin` across Jenkins restarts

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/actions/ErrorActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/actions/ErrorActionTest.java
@@ -42,7 +42,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 
 import hudson.model.Result;
 import hudson.remoting.ProxyException;
@@ -56,7 +56,7 @@ public class ErrorActionTest {
     public static BuildWatcher buildWatcher = new BuildWatcher();
 
     @Rule
-    public JenkinsRule r = new JenkinsRule();
+    public JenkinsSessionRule rr = new JenkinsSessionRule();
 
     private List<ErrorAction> extractErrorActions(FlowExecution exec) {
         List<ErrorAction> ret = new ArrayList<>();
@@ -72,105 +72,117 @@ public class ErrorActionTest {
     }
 
     @Test
-    public void simpleException() throws Exception {
-        final String EXPECTED = "For testing purpose";
-        WorkflowJob job = r.jenkins.createProject(WorkflowJob.class, "p");
-        job.setDefinition(new CpsFlowDefinition(String.format(
-                "node {\n"
-                        + "throw new Exception('%s');\n"
-                + "}"
-                , EXPECTED
-        ), true));
-        WorkflowRun b = r.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
-        List<ErrorAction> errorActionList = extractErrorActions(b.asFlowExecutionOwner().get());
-        assertThat(errorActionList, Matchers.not(Matchers.empty()));
-        for (ErrorAction e : errorActionList) {
-            assertEquals(Exception.class, e.getError().getClass());
-            assertEquals(EXPECTED, e.getError().getMessage());
-        }
+    public void simpleException() throws Throwable {
+        rr.then(r -> {
+            final String EXPECTED = "For testing purpose";
+            WorkflowJob job = r.jenkins.createProject(WorkflowJob.class, "p");
+            job.setDefinition(new CpsFlowDefinition(String.format(
+                    "node {\n"
+                            + "throw new Exception('%s');\n"
+                    + "}"
+                    , EXPECTED
+            ), true));
+            WorkflowRun b = r.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
+            List<ErrorAction> errorActionList = extractErrorActions(b.asFlowExecutionOwner().get());
+            assertThat(errorActionList, Matchers.not(Matchers.empty()));
+            for (ErrorAction e : errorActionList) {
+                assertEquals(Exception.class, e.getError().getClass());
+                assertEquals(EXPECTED, e.getError().getMessage());
+            }
+        });
     }
 
     @Issue("JENKINS-34488")
     @Test
-    public void unserializableForSecurityReason() throws Exception {
-        final String FAILING_EXPRESSION = "(2 + 2) == 5";
-        WorkflowJob job = r.jenkins.createProject(WorkflowJob.class, "p");
-        // "assert false" throws org.codehaus.groovy.runtime.powerassert.PowerAssertionError,
-        // which is rejected by remoting.
-        job.setDefinition(new CpsFlowDefinition(String.format(
-                "node {\n"
-                        + "assert %s;\n"
-                + "}",
-                FAILING_EXPRESSION
-        ), true));
-        WorkflowRun b = r.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
-        r.assertLogContains(FAILING_EXPRESSION, b); // ensure that failed with the assertion.
-        List<ErrorAction> errorActionList = extractErrorActions(b.asFlowExecutionOwner().get());
-        assertThat(errorActionList, Matchers.not(Matchers.empty()));
-        for (ErrorAction e : errorActionList) {
-            assertEquals(ProxyException.class, e.getError().getClass());
-        }
+    public void unserializableForSecurityReason() throws Throwable {
+        rr.then(r -> {
+            final String FAILING_EXPRESSION = "(2 + 2) == 5";
+            WorkflowJob job = r.jenkins.createProject(WorkflowJob.class, "p");
+            // "assert false" throws org.codehaus.groovy.runtime.powerassert.PowerAssertionError,
+            // which is rejected by remoting.
+            job.setDefinition(new CpsFlowDefinition(String.format(
+                    "node {\n"
+                            + "assert %s;\n"
+                    + "}",
+                    FAILING_EXPRESSION
+            ), true));
+            WorkflowRun b = r.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
+            r.assertLogContains(FAILING_EXPRESSION, b); // ensure that failed with the assertion.
+            List<ErrorAction> errorActionList = extractErrorActions(b.asFlowExecutionOwner().get());
+            assertThat(errorActionList, Matchers.not(Matchers.empty()));
+            for (ErrorAction e : errorActionList) {
+                assertEquals(ProxyException.class, e.getError().getClass());
+            }
+        });
     }
 
     @Issue("JENKINS-39346")
-    @Test public void wrappedUnserializableException() throws Exception {
-        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition(
-            "catchError {\n" +
-            "  try {\n" +
-            "    try {\n" +
-            "      throw new NullPointerException('oops')\n" +
-            "    } catch (e) {\n" +
-            "      throw new org.codehaus.groovy.runtime.InvokerInvocationException(e)\n" + // TODO is there a way to convince Groovy to throw this on its own?
-            "    }\n" +
-            "  } catch (e) {\n" +
-            "    throw new IllegalArgumentException(e)\n" +
-            "  }\n" +
-            "}\n" +
-            "echo 'got to the end'", false /* for the three types of exceptions thrown in the pipeline */));
-        WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-        r.assertLogContains("got to the end", b);
-        r.assertLogContains("java.lang.NullPointerException: oops", b);
+    @Test public void wrappedUnserializableException() throws Throwable {
+        rr.then(r -> {
+            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition(
+                "catchError {\n" +
+                "  try {\n" +
+                "    try {\n" +
+                "      throw new NullPointerException('oops')\n" +
+                "    } catch (e) {\n" +
+                "      throw new org.codehaus.groovy.runtime.InvokerInvocationException(e)\n" + // TODO is there a way to convince Groovy to throw this on its own?
+                "    }\n" +
+                "  } catch (e) {\n" +
+                "    throw new IllegalArgumentException(e)\n" +
+                "  }\n" +
+                "}\n" +
+                "echo 'got to the end'", false /* for the three types of exceptions thrown in the pipeline */));
+            WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+            r.assertLogContains("got to the end", b);
+            r.assertLogContains("java.lang.NullPointerException: oops", b);
+        });
     }
 
     @Issue("JENKINS-49025")
-    @Test public void nestedFieldUnserializable() throws Exception {
-        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition(
-            "catchError {\n" +
-            "  throw new " + X.class.getCanonicalName() + "()\n" +
-            "}\n" +
-            "echo 'got to the end'", false /* for "new org.jenkinsci.plugins.workflow.actions.ErrorActionTest$X" */));
-        WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-        r.assertLogContains("got to the end", b);
-        r.assertLogContains(X.class.getName(), b);
-        List<ErrorAction> errorActionList = extractErrorActions(b.asFlowExecutionOwner().get());
-        assertThat(errorActionList, Matchers.not(Matchers.empty()));
-        for (ErrorAction e : errorActionList) {
-            assertEquals(ProxyException.class, e.getError().getClass());
-        }
+    @Test public void nestedFieldUnserializable() throws Throwable {
+        rr.then(r -> {
+            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition(
+                "catchError {\n" +
+                "  throw new " + X.class.getCanonicalName() + "()\n" +
+                "}\n" +
+                "echo 'got to the end'", false /* for "new org.jenkinsci.plugins.workflow.actions.ErrorActionTest$X" */));
+            WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+            r.assertLogContains("got to the end", b);
+            r.assertLogContains(X.class.getName(), b);
+            List<ErrorAction> errorActionList = extractErrorActions(b.asFlowExecutionOwner().get());
+            assertThat(errorActionList, Matchers.not(Matchers.empty()));
+            for (ErrorAction e : errorActionList) {
+                assertEquals(ProxyException.class, e.getError().getClass());
+            }
+        });
     }
     public static class X extends Exception {
         final NullObject nil = NullObject.getNullObject();
     }
 
-    @Test public void userDefinedError() throws Exception {
-        WorkflowJob p = r.createProject(WorkflowJob.class);
-        p.setDefinition(new CpsFlowDefinition(
-                "class MyException extends Exception {\n" +
-                "  MyException(String message) { super(message) }\n" +
-                "}\n" +
-                "throw new MyException('test')\n",
-                true));
-        WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
-        assertThat(b.getExecution().getCauseOfFailure(), Matchers.instanceOf(ProxyException.class));
+    @Test public void userDefinedError() throws Throwable {
+        rr.then(r -> {
+            WorkflowJob p = r.createProject(WorkflowJob.class);
+            p.setDefinition(new CpsFlowDefinition(
+                    "class MyException extends Exception {\n" +
+                    "  MyException(String message) { super(message) }\n" +
+                    "}\n" +
+                    "throw new MyException('test')\n",
+                    true));
+            WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+            assertThat(b.getExecution().getCauseOfFailure(), Matchers.instanceOf(ProxyException.class));
+        });
     }
 
-    @Test public void missingPropertyExceptionMemoryLeak() throws Exception {
-        WorkflowJob p = r.createProject(WorkflowJob.class);
-        p.setDefinition(new CpsFlowDefinition("FOO", false));
-        WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
-        assertThat(b.getExecution().getCauseOfFailure(), Matchers.instanceOf(ProxyException.class));
+    @Test public void missingPropertyExceptionMemoryLeak() throws Throwable {
+        rr.then(r -> {
+            WorkflowJob p = r.createProject(WorkflowJob.class);
+            p.setDefinition(new CpsFlowDefinition("FOO", false));
+            WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+            assertThat(b.getExecution().getCauseOfFailure(), Matchers.instanceOf(ProxyException.class));
+        });
     }
 
 }


### PR DESCRIPTION
`ErrorAction.findOrigin` currently returns different a `FlowNode` before and after a Jenkins restart if the original error is inside of a branch in a `parallel` step and multiple branches fail (and likely in various other cases). This PR makes it so that the same `FlowNode` is returned regardless of whether Jenkins is restarted (in most cases) by ignoring suppressed exceptions when checking equality.

The problem is that before restarting Jenkins, we are able to simply check reference equality here when finding the origin of an error:

https://github.com/jenkinsci/workflow-api-plugin/blob/0cc7c6e0da9e89b4ed99edf8e830990014fca727/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java#L147

Reference equality is robust against modifications made to the original `Throwable` when it gets thrown to enclosing blocks. For example, calls to `setStackTrace` or `addSuppressedException` do not break reference equality.

However, after restarting Jenkins, we will deserialize new instances of all of the `ErrorAction`s in `FlowNode` XML files, breaking reference equality of the underlying errors, so we have to check types and stack traces:

https://github.com/jenkinsci/workflow-api-plugin/blob/0cc7c6e0da9e89b4ed99edf8e830990014fca727/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java#L149-L153

The stack trace of the serialized errors are frozen at the time they are written to disk. This means that the calls to `setStackTrace` or `addSuppressedException` made after the error is serialized break the ability of `findOrigin` to find the origin as desired.

### Testing done

See new automated tests.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
