### PR TITLE
Track identity of errors passed to `ErrorAction` to improve consistency of `ErrorAction.findOrigin` across restarts

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/actions/ErrorActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/actions/ErrorActionTest.java
@@ -198,7 +198,6 @@ public class ErrorActionTest {
                     "parallel(one: { node {" + script + "} }, two: { node {" + script + "} })", true));
             WorkflowRun b = r.buildAndAssertStatus(Result.FAILURE, p);
             FlowNode originNode = ErrorAction.findOrigin(b.getExecution().getCauseOfFailure(), b.getExecution());
-            originNode.getPersistentAction(ErrorAction.class).getError().printStackTrace();
             origin.set(originNode.getId());
         });
         rr.then(r -> {
@@ -209,7 +208,6 @@ public class ErrorActionTest {
         });
     }
 
-    @Ignore("See note in ErrorAction#findOrigin")
     @Test public void findOriginOfSyncErrorAcrossRestart() throws Throwable {
         String name = "restart";
         AtomicReference<String> origin = new AtomicReference<>();


### PR DESCRIPTION
See https://github.com/jenkinsci/workflow-api-plugin/pull/284#discussion_r1190274670.

### Testing done

See unignored test.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
