### PR TITLE
Make ErrorAction.equals a public API

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -43,6 +43,8 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.AtomNode;
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
 import org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
 
 /**
  * Attached to {@link FlowNode} that caused an error.
@@ -165,7 +167,8 @@ public class ErrorAction implements PersistentAction {
      * {@link Throwable#equals} might not be reliable if the program has resumed
      * and stuff is deserialized.
      */
-    private static boolean equals(Throwable t1, Throwable t2) {
+    @Restricted(Beta.class)
+    public static boolean equals(Throwable t1, Throwable t2) {
         if (t1 == t2) {
             return true;
         } else if (t1.getClass() != t2.getClass()) {


### PR DESCRIPTION
`ErrorAction.findOrigin` is useful, but can be prohibitively slow in complex Pipelines with a lot of errors, as it scans the entire flow graph. In particular, I have a case where I only need to know whether a specific `ErrorAction` represents an original or re-thrown error, and `findOrigin` is currently the only way to get access to the `ErrorId` equality logic.

This PR exposes `ErrorAction.equals` so that other plugins can check error originality using more limited scans in cases where finding the true origin of an error is unnecessary and too slow.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
