### PR TITLE
[JENKINS-56446] Do not permanently close the log stream in FileLogStorage if an interrupted thread attempts to write to it

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java
@@ -77,7 +77,9 @@ public final class FileLogStorage implements LogStorage {
     private final File index;
     @SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC", justification = "actually it is always accessed within the monitor")
     private FileOutputStream os;
+    @SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC", justification = "actually it is always accessed within the monitor")
     private long osStartPosition;
+    @SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC", justification = "actually it is always accessed within the monitor")
     private CountingOutputStream cos;
     @SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC", justification = "we only care about synchronizing writes")
     private OutputStream bos;

--- a/src/test/java/org/jenkinsci/plugins/workflow/log/FileLogStorageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/log/FileLogStorageTest.java
@@ -55,4 +55,18 @@ public class FileLogStorageTest extends LogStorageTestBase {
         assertOverallLog(0, lines("stuff"), true);
     }
 
+    @Test public void interruptionDoesNotCloseStream() throws Exception {
+        LogStorage ls = createStorage();
+        TaskListener overall = ls.overallListener();
+        overall.getLogger().println("overall 1");
+        Thread.currentThread().interrupt();
+        TaskListener stepLog = ls.nodeListener(new MockNode("1"));
+        stepLog.getLogger().println("step 1");
+        assertTrue(Thread.interrupted());
+        close(stepLog);
+        overall.getLogger().println("overall 2");
+        close(overall);
+        assertOverallLog(0, lines("overall 1", "<span class=\"pipeline-node-1\">step 1", "</span>overall 2"), true);
+    }
+
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
@@ -350,12 +350,12 @@ public abstract class LogStorageTestBase {
         return String.join(System.lineSeparator(), lines) + System.lineSeparator();
     }
 
-    private static class MockNode extends FlowNode {
+    protected static class MockNode extends FlowNode {
         MockNode(String id) {super(new MockFlowExecution(), id);}
         @Override protected String getTypeDisplayName() {return null;}
     }
 
-    private static class MockFlowExecution extends FlowExecution {
+    protected static class MockFlowExecution extends FlowExecution {
         @Override
         public void start() {
             throw new UnsupportedOperationException();

--- a/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/log/LogStorageTestBase.java
@@ -355,7 +355,7 @@ public abstract class LogStorageTestBase {
         @Override protected String getTypeDisplayName() {return null;}
     }
 
-    protected static class MockFlowExecution extends FlowExecution {
+    private static class MockFlowExecution extends FlowExecution {
         @Override
         public void start() {
             throw new UnsupportedOperationException();


### PR DESCRIPTION
See [JENKINS-56446](https://issues.jenkins.io/browse/JENKINS-56446).

While investigating other changes I finally tracked down an issue I have seen before where the main Pipeline log gets closed for some unknown reason, blocking all further writes. I will look for a JENKINS ticket shortly, and I know there is a CloudBees-internal ticket about this issue.

The problem is that `FileLogStorage.checkId` uses a `FileChannel` method to get the current position of the log whenever the log output switches from one step to another. `FileChannel` methods close the channel, and in this case the stream it was derived from, if the thread is interrupted when performing any IO operations. This behavior is undesirable for Pipeline, because it means that any thread writing log output for a step has the ability to inadvertently close the log stream permanently if that thread is interrupted, even if the interruption is expected/controlled (e.g. the `timeout` step).

For some additional context, I also saw a similar issue with another implementation of `LogStorage` that attempted to use `FileChannel`, and in that case we avoided it completely in favor of plain `FileOutputStream` to fix the issue.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
