### PR TITLE
Add `LogStorage` utility methods that expose the functionality of `BufferedBuildListener`, `DelayBufferedOutputStream`, and `GCFlushedOutputStream`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java
@@ -96,7 +96,7 @@ public final class FileLogStorage implements LogStorage {
             os = new FileOutputStream(log, true);
             osStartPosition = log.length();
             cos = new CountingOutputStream(os);
-            bos = new GCFlushedOutputStream(new DelayBufferedOutputStream(cos));
+            bos = LogStorage.wrapWithAutoFlushingBuffer(cos);
             if (index.isFile()) {
                 try (BufferedReader r = Files.newBufferedReader(index.toPath(), StandardCharsets.UTF_8)) {
                     // TODO would be faster to scan the file backwards for the penultimate \n, then convert the byte sequence from there to EOF to UTF-8 and set lastId accordingly
@@ -124,12 +124,12 @@ public final class FileLogStorage implements LogStorage {
 
     @NonNull
     @Override public BuildListener overallListener() throws IOException {
-        return new BufferedBuildListener(new IndexOutputStream(null));
+        return LogStorage.wrapWithRemoteAutoFlushingListener(new IndexOutputStream(null));
     }
 
     @NonNull
     @Override public TaskListener nodeListener(@NonNull FlowNode node) throws IOException {
-        return new BufferedBuildListener(new IndexOutputStream(node.getId()));
+        return LogStorage.wrapWithRemoteAutoFlushingListener(new IndexOutputStream(node.getId()));
     }
 
     private void checkId(String id) throws IOException {

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/LogStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/LogStorage.java
@@ -174,4 +174,19 @@ public interface LogStorage {
         }
     }
 
+    /**
+     * Wraps the specified {@link OutputStream} with a {@link BuildListener} that automatically buffers and flushes
+     * remote writes.
+     */
+    static @NonNull BuildListener wrapWithRemoteAutoFlushingListener(@NonNull OutputStream os) throws IOException {
+        return new BufferedBuildListener(os);
+    }
+
+    /**
+     * Wraps the specified {@link OutputStream} with a buffer that flushes automatically as needed.
+     */
+    static @NonNull OutputStream wrapWithAutoFlushingBuffer(@NonNull OutputStream os) throws IOException {
+        return new GCFlushedOutputStream(new DelayBufferedOutputStream(os));
+    }
+
 }


### PR DESCRIPTION
`LogStorage` implementations that are similar to `FileLogStorage` need to be able to use the same logic as `BufferedBuildListener`, `DelayBufferedOutputStream`, and `GCFlushedOutputStream` for both performance and correctness reasons, so we should expose these classes' functionality.

I think we can just add two methods to wrap a given `OutputStream` as needed without having to fully expose the classes. I am not sure what name would be best, feel free to recommend whatever you like.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
