### PR TITLE
Do not unregister completed executions when iterating over `FlowExecutionList` to avoid unnecessary log warnings

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -80,7 +80,7 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
      */
     @Override
     public Iterator<FlowExecution> iterator() {
-        return new AbstractIterator<FlowExecution>() {
+        return new AbstractIterator<>() {
             final Iterator<FlowExecutionOwner> base = runningTasks.iterator();
 
             @Override
@@ -88,12 +88,7 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
                 while (base.hasNext()) {
                     FlowExecutionOwner o = base.next();
                     try {
-                        FlowExecution e = o.get();
-                        if (e.isComplete()) {
-                            unregister(o);
-                        } else {
-                            return e;
-                        }
+                        return o.get();
                     } catch (Throwable e) {
                         LOGGER.log(Level.FINE, "Failed to load " + o + ". Unregistering", e);
                         unregister(o);

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -208,8 +208,11 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
         public void onLoaded() {
             FlowExecutionList list = FlowExecutionList.get();
             for (final FlowExecution e : list) {
-                // The call to FlowExecutionOwner.get in the implementation of iterator() is sufficent to load the Pipeline.
+                // The call to FlowExecutionOwner.get in the implementation of iterator() is sufficient to load the Pipeline.
                 LOGGER.log(Level.FINE, "Eagerly loaded {0}", e);
+                if (e.isComplete()) {
+                    list.unregister(e.getOwner());
+                }
             }
             list.resumptionComplete = true;
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -88,7 +88,10 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
                 while (base.hasNext()) {
                     FlowExecutionOwner o = base.next();
                     try {
-                        return o.get();
+                        FlowExecution e = o.get();
+                        if (!e.isComplete()) {
+                            return e;
+                        }
                     } catch (Throwable e) {
                         LOGGER.log(Level.FINE, "Failed to load " + o + ". Unregistering", e);
                         unregister(o);


### PR DESCRIPTION
cf. https://github.com/jenkinsci/kubernetes-plugin/pull/1342#issuecomment-1692993104

<!-- Please describe your pull request here. -->

### Testing done

AFAIU to reproduce the issue would require to set up a cloud agent. On its termination, it calls indirectly `computeNext()` which unregisters the `FlowExecutionOwner` if it is the last node in the pipeline. Then the regular `unregister` call when the `WorkflowRun` completes now issues a warning because it has already been unregistered.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
