### PR TITLE
Make ForkScanner visit parallel branches for incomplete parallel steps in a more consistent order (ideally reverse declaration order)

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScannerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/graphanalysis/FlowScannerTest.java
@@ -390,11 +390,11 @@ public class FlowScannerTest {
         // Test forkscanner inside a parallel
         List<FlowNode> startingPoints = Arrays.asList(exec.getNode("9"), exec.getNode("12"));
         scanner.setup(startingPoints);
-        FlowTestUtils.assertNodeOrder("ForkedScanner", scanner, 9, 8, 6, 12, 11, 10, 7, 4, 3, 2);
+        FlowTestUtils.assertNodeOrder("ForkedScanner", scanner, 12, 11, 10, 7, 9, 8, 6, 4, 3, 2);
 
         startingPoints = Arrays.asList(exec.getNode("9"), exec.getNode("11"));
         scanner.setup(startingPoints);
-        FlowTestUtils.assertNodeOrder("ForkedScanner", scanner, 9, 8, 6, 11, 10, 7, 4, 3, 2);
+        FlowTestUtils.assertNodeOrder("ForkedScanner", scanner, 11, 10, 7, 9, 8, 6, 4, 3, 2);
 
 
         // Filtering at different points within branches


### PR DESCRIPTION
Builds on top of #302 to make it easier to test both of them together, but a separate PR because because I think this will need further investigation.

Here is the effective diff: https://github.com/dwnusbaum/workflow-api-plugin/compare/more-forkscanner-problems...dwnusbaum:workflow-api-plugin:more-forkscanner-problems-2

There are two things I am trying to fix in this PR:
* We want `ForkScanner` to visit parallel branches in the same order regardless of whether the build is complete or not
* We want that order to be the reverse of the declared order of the branches in the Pipeline script

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
