### PR TITLE
[JENKINS-71970] Memory leak involving `BufferedBuildListener`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/log/BufferedBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/BufferedBuildListener.java
@@ -47,6 +47,8 @@ import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
  */
 final class BufferedBuildListener extends OutputStreamTaskListener.Default implements BuildListener, Closeable, SerializableOnlyOverRemoting {
 
+    private static final long serialVersionUID = 1;
+
     private static final Logger LOGGER = Logger.getLogger(BufferedBuildListener.class.getName());
 
     private static final Cleaner cleaner = Cleaner.create(new NamingThreadFactory(new DaemonThreadFactory(), BufferedBuildListener.class.getName() + ".cleaner"));

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/BufferedBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/BufferedBuildListener.java
@@ -29,12 +29,15 @@ import hudson.model.BuildListener;
 import hudson.remoting.Channel;
 import hudson.remoting.ChannelClosedException;
 import hudson.remoting.RemoteOutputStream;
+import hudson.util.DaemonThreadFactory;
+import hudson.util.NamingThreadFactory;
 import hudson.util.StreamTaskListener;
 import java.io.Closeable;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.lang.ref.Cleaner;
 import java.util.logging.Logger;
 import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
 
@@ -46,10 +49,23 @@ final class BufferedBuildListener extends OutputStreamTaskListener.Default imple
 
     private static final Logger LOGGER = Logger.getLogger(BufferedBuildListener.class.getName());
 
+    private static final Cleaner cleaner = Cleaner.create(new NamingThreadFactory(new DaemonThreadFactory(), BufferedBuildListener.class.getName() + ".cleaner"));
+
     private final OutputStream out;
+    private final Channel channel;
+    private final Listener listener;
 
     BufferedBuildListener(OutputStream out) {
         this.out = out;
+        if (out instanceof CloseableOutputStream) {
+            channel = Channel.currentOrFail();
+            listener = new Listener((CloseableOutputStream) out, channel);
+            channel.addListener(listener);
+            cleaner.register(this, listener);
+        } else {
+            channel = null;
+            listener = null;
+        }
     }
 
     @Override public OutputStream getOutputStream() {
@@ -58,10 +74,30 @@ final class BufferedBuildListener extends OutputStreamTaskListener.Default imple
 
     @Override public void close() throws IOException {
         getLogger().close();
+        if (listener != null) {
+            channel.removeListener(listener);
+        }
     }
 
     private Object writeReplace() {
         return new Replacement(this);
+    }
+
+    private static final class Listener extends Channel.Listener implements Runnable {
+        private final CloseableOutputStream cos;
+        private final Channel channel;
+        Listener(CloseableOutputStream cos, Channel channel) {
+            this.cos = cos;
+            this.channel = channel;
+        }
+        @Override public void onClosed(Channel channel, IOException cause) {
+            LOGGER.fine(() -> "closing " + channel.getName());
+            cos.close(channel, cause);
+            channel.removeListener(this);
+        }
+        @Override public void run() {
+            channel.removeListener(this);
+        }
     }
 
     private static final class Replacement implements SerializableOnlyOverRemoting {
@@ -76,15 +112,7 @@ final class BufferedBuildListener extends OutputStreamTaskListener.Default imple
         }
 
         private Object readResolve() {
-            var cos = new CloseableOutputStream(new GCFlushedOutputStream(new DelayBufferedOutputStream(ros, tuning)));
-            Channel.currentOrFail().addListener(new Channel.Listener() {
-                @Override public void onClosed(Channel channel, IOException cause) {
-                    LOGGER.fine(() -> "closing " + channel.getName());
-                    cos.close(channel, cause);
-                    channel.removeListener(this);
-                }
-            });
-            return new BufferedBuildListener(cos);
+            return new BufferedBuildListener(new CloseableOutputStream(new GCFlushedOutputStream(new DelayBufferedOutputStream(ros, tuning))));
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/log/BufferedBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/BufferedBuildListener.java
@@ -52,8 +52,8 @@ final class BufferedBuildListener extends OutputStreamTaskListener.Default imple
     private static final Cleaner cleaner = Cleaner.create(new NamingThreadFactory(new DaemonThreadFactory(), BufferedBuildListener.class.getName() + ".cleaner"));
 
     private final OutputStream out;
-    private final Channel channel;
-    private final Listener listener;
+    private transient final Channel channel;
+    private transient final Listener listener;
 
     BufferedBuildListener(OutputStream out) {
         this.out = out;


### PR DESCRIPTION
[JENKINS-71970](https://issues.jenkins.io/browse/JENKINS-71970), amending #309.

Reproduced by running `mvn hpi:run` with

```diff
diff --git pom.xml pom.xml
index c4482a2..646fe12 100644
--- pom.xml
+++ pom.xml
@@ -63,7 +63,7 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.version>2.414.1</jenkins.version>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -72,8 +72,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>2102.v854b_fec19c92</version>
+                <artifactId>bom-2.414.x</artifactId>
+                <version>2423.vce598171d115</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
```

plus updating `workflow-support` from UC and installing `mock-slave`, creating a mock slave, and running

```groovy
node('static') {
    int i = 0
    while (true) {
        sh "echo ${i}"
        i++
    }
}
```

then

```bash
watch 'jmap -histo:live …
```

or

```bash
watch 'jmap -histo:live … | fgrep BufferedBuildListener'
```

There were multiple issues. First of all, removing the listener on `Channel.onClosed` is not enough (and may in fact be useless) when there are lots of different listeners being created while the channel is open. The listener needed to be associated with the stream (`BufferedBuildListener`), not its `Replacement` which is intended to be transient. Closing the stream (if that ever happens) should also remove the listener. And collecting the stream (which happens routinely) should remove the listener.

With the fix, I was able to run thousands of `sh` steps in a row on the same open agent channel, and memory did not increase significantly (in particular the `byte[]` usage would go up to ~10Mb but then drop again), nor did any classes from this package stay in the top screenful.
