### PR TITLE
Adapt DirectArtifactManagerFactory to run test on IPv6

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/DirectArtifactManagerFactory.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/DirectArtifactManagerFactory.java
@@ -102,7 +102,7 @@ public final class DirectArtifactManagerFactory extends ArtifactManagerFactory {
             }).
             create();
         server.start();
-        baseURL = new URL("http://" + server.getInetAddress().getHostName() + ":" + server.getLocalPort() + "/");
+        baseURL = new URL("http", server.getInetAddress().getHostName(), server.getLocalPort(), "/");
         LOGGER.log(Level.INFO, "Mock server running at {0}", baseURL);
 
     }


### PR DESCRIPTION
### Highlights
- Current use of URL builder does not cover IPv6
- If we run a test using this code on an IPv6 environment we will get the following exception
```
java.net.MalformedURLException: Error at index 0 in: "::45033"
	at java.base/java.net.URL.<init>(URL.java:679)
	at java.base/java.net.URL.<init>(URL.java:541)
	at java.base/java.net.URL.<init>(URL.java:488)
	at org.jenkinsci.plugins.workflow.DirectArtifactManagerFactory.<init>(DirectArtifactManagerFactory.java:105)
```
- This PR changes the URL builder invocation to a compliant one with both IPv4 and IPv6 addresses format

### Testing done
- Tested via PCT on an IPv6 environment and working as expected

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
