### PR TITLE
Take out a file lock on the `log` file

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java
@@ -94,6 +94,9 @@ public final class FileLogStorage implements LogStorage {
     private synchronized void open() throws IOException {
         if (os == null) {
             os = new FileOutputStream(log, true);
+            LOGGER.fine(() -> "locking " + log + "…");
+            os.getChannel().lock();
+            LOGGER.fine(() -> "…locked " + log);
             osStartPosition = log.length();
             cos = new CountingOutputStream(os);
             bos = LogStorage.wrapWithAutoFlushingBuffer(cos);
@@ -189,6 +192,7 @@ public final class FileLogStorage implements LogStorage {
                 openStorages.remove(log);
                 try {
                     bos.close();
+                    LOGGER.fine(() -> "closed " + log + " which should have released its lock");
                 } finally {
                     indexOs.close();
                 }


### PR DESCRIPTION
Just experimenting at this point. Does not seem to regress the test added in #296.