### PR TITLE
Fix origin identification for unserializable exceptions

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -42,7 +42,7 @@ import org.apache.commons.io.output.NullOutputStream;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.AtomNode;
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
-import org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner;
+import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
 
@@ -56,20 +56,25 @@ public class ErrorAction implements PersistentAction {
     private final @NonNull Throwable error;
 
     public ErrorAction(@NonNull Throwable error) {
+        Throwable errorForAction = error;
         if (isUnserializableException(error, new HashSet<>())) {
-            error = new ProxyException(error);
+            errorForAction = new ProxyException(error);
         } else if (error != null) {
             try {
                 Jenkins.XSTREAM2.toXMLUTF8(error, new NullOutputStream());
             } catch (Exception x) {
                 // Typically SecurityException from ClassFilter.
-                error = new ProxyException(error);
+                errorForAction = new ProxyException(error);
             }
         }
-        this.error = error;
+        this.error = errorForAction;
         String id = findId(error, new HashSet<>());
         if (id == null && error != null) {
-            error.addSuppressed(new ErrorId());
+            errorForAction.addSuppressed(new ErrorId());
+            if (error != errorForAction) {
+                // Make sure the original exception has the error ID, not just the copy here.
+                error.addSuppressed(new ErrorId());
+            }
         }
     }
 
@@ -140,7 +145,7 @@ public class ErrorAction implements PersistentAction {
      */
     public static @CheckForNull FlowNode findOrigin(@NonNull Throwable error, @NonNull FlowExecution execution) {
         FlowNode candidate = null;
-        for (FlowNode n : new ForkScanner().allNodes(execution)) {
+        for (FlowNode n : new DepthFirstScanner().allNodes(execution)) {
             ErrorAction errorAction = n.getPersistentAction(ErrorAction.class);
             if (errorAction != null && equals(error, errorAction.getError())) {
                 candidate = n; // continue search for earlier one

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -176,9 +176,11 @@ public class ErrorAction implements PersistentAction {
     public static boolean equals(Throwable t1, Throwable t2) {
         if (t1 == t2) {
             return true;
-        } else if (t1.getClass() != t2.getClass()) {
+        }
+        boolean noProxy = t1.getClass() != ProxyException.class && t2.getClass() != ProxyException.class;
+        if (noProxy && t1.getClass() != t2.getClass()) {
             return false;
-        } else if (!Objects.equals(t1.getMessage(), t2.getMessage())) {
+        } else if (noProxy && !Objects.equals(t1.getMessage(), t2.getMessage())) {
             return false;
         } else {
             String id1 = findId(t1, new HashSet<>());

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -42,7 +42,7 @@ import org.apache.commons.io.output.NullOutputStream;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.AtomNode;
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
-import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
+import org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
 
@@ -145,7 +145,7 @@ public class ErrorAction implements PersistentAction {
      */
     public static @CheckForNull FlowNode findOrigin(@NonNull Throwable error, @NonNull FlowExecution execution) {
         FlowNode candidate = null;
-        for (FlowNode n : new DepthFirstScanner().allNodes(execution)) {
+        for (FlowNode n : new ForkScanner().allNodes(execution)) {
             ErrorAction errorAction = n.getPersistentAction(ErrorAction.class);
             if (errorAction != null && equals(error, errorAction.getError())) {
                 candidate = n; // continue search for earlier one


### PR DESCRIPTION
For exceptions which were not serializable, we previously only added `ErrorId` to the `ProxyException` created for serialization purposes. The original exception that was thrown up through the Pipeline's execution would have no `ErrorId`, so each block/step that failed due to the exception would get a fresh `ErrorId`.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
