### PR TITLE
`ErrorAction.findOrigin` failures due to `ProxyException`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.426.x</artifactId>
-                <version>2555.v3190a_8a_c60c6</version>
+                <version>2745.vc7b_fe4c876fa_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -76,10 +76,11 @@ public class ErrorAction implements PersistentAction {
         this.error = errorForAction;
         String id = findId(error, new HashSet<>());
         if (id == null) {
-            errorForAction.addSuppressed(new ErrorId());
+            var errorId = new ErrorId();
+            errorForAction.addSuppressed(errorId);
             if (error != errorForAction) {
                 // Make sure the original exception has the error ID, not just the copy here.
-                error.addSuppressed(new ErrorId());
+                error.addSuppressed(errorId);
             }
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -185,24 +185,25 @@ public class ErrorAction implements PersistentAction {
             LOGGER.fine(() -> "Same object: " + t1);
             return true;
         }
-        String id1 = findId(t1, new HashSet<>());
-        if (id1 != null) {
-            String id2 = findId(t2, new HashSet<>());
-            if (id1.equals(id2)) {
-                LOGGER.fine(() -> "ErrorId matches: " + id1);
-                return true;
-            }
-            LOGGER.fine(() -> "ErrorId mismatch: " + t1 + " " + id1 + " vs. " + t2 + " " + id2);
-        } else {
-            LOGGER.fine(() -> "No ErrorId on " + t1);
-        }
-        if (t1.getClass() != t2.getClass()) {
+        boolean noProxy = t1.getClass() != ProxyException.class && t2.getClass() != ProxyException.class;
+        if (noProxy && t1.getClass() != t2.getClass()) {
             LOGGER.fine(() -> "Different types: " + t1.getClass() + " vs. " + t2.getClass());
             return false;
-        } else if (!Objects.equals(t1.getMessage(), t2.getMessage())) {
+        } else if (noProxy && !Objects.equals(t1.getMessage(), t2.getMessage())) {
             LOGGER.fine(() -> "Different messages: " + t1.getMessage() + " vs. " + t2.getMessage());
             return false;
         } else {
+            String id1 = findId(t1, new HashSet<>());
+            if (id1 != null) {
+                String id2 = findId(t2, new HashSet<>());
+                if (id1.equals(id2)) {
+                    LOGGER.fine(() -> "ErrorId matches: " + id1);
+                    return true;
+                } else {
+                    LOGGER.fine(() -> "ErrorId mismatch: " + t1 + " " + id1 + " vs. " + t2 + " " + id2);
+                    return false;
+                }
+            }
             // No ErrorId, use a best-effort approach that doesn't work across restarts for exceptions thrown
             // synchronously from the CPS VM thread.
             // Check that stack traces match, but specifically avoid checking suppressed exceptions, which are often

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -183,19 +183,25 @@ public class ErrorAction implements PersistentAction {
         if (t1 == t2) {
             LOGGER.fine(() -> "Same object: " + t1);
             return true;
-        } else if (t1.getClass() != t2.getClass()) {
+        }
+        String id1 = findId(t1, new HashSet<>());
+        if (id1 != null) {
+            String id2 = findId(t2, new HashSet<>());
+            if (id1.equals(id2)) {
+                LOGGER.fine(() -> "ErrorId matches: " + id1);
+                return true;
+            }
+            LOGGER.fine(() -> "ErrorId mismatch: " + t1 + " " + id1 + " vs. " + t2 + " " + id2);
+        } else {
+            LOGGER.fine(() -> "No ErrorId on " + t1);
+        }
+        if (t1.getClass() != t2.getClass()) {
             LOGGER.fine(() -> "Different types: " + t1.getClass() + " vs. " + t2.getClass());
             return false;
         } else if (!Objects.equals(t1.getMessage(), t2.getMessage())) {
             LOGGER.fine(() -> "Different messages: " + t1.getMessage() + " vs. " + t2.getMessage());
             return false;
         } else {
-            String id1 = findId(t1, new HashSet<>());
-            if (id1 != null) {
-                String id2 = findId(t2, new HashSet<>());
-                LOGGER.fine(() -> "ErrorId comparisons: " + id1 + " vs. " + id2);
-                return id1.equals(id2);
-            }
             // No ErrorId, use a best-effort approach that doesn't work across restarts for exceptions thrown
             // synchronously from the CPS VM thread.
             // Check that stack traces match, but specifically avoid checking suppressed exceptions, which are often

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -44,7 +44,7 @@ import org.apache.commons.io.output.NullOutputStream;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.AtomNode;
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
-import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
+import org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
 
@@ -151,7 +151,7 @@ public class ErrorAction implements PersistentAction {
      */
     public static @CheckForNull FlowNode findOrigin(@NonNull Throwable error, @NonNull FlowExecution execution) {
         FlowNode candidate = null;
-        for (FlowNode n : new DepthFirstScanner().allNodes(execution)) {
+        for (FlowNode n : new ForkScanner().allNodes(execution)) {
             ErrorAction errorAction = n.getPersistentAction(ErrorAction.class);
             if (errorAction != null && equals(error, errorAction.getError())) {
                 candidate = n; // continue search for earlier one

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -75,7 +75,7 @@ public class ErrorAction implements PersistentAction {
         }
         this.error = errorForAction;
         String id = findId(error, new HashSet<>());
-        if (id == null && error != null) {
+        if (id == null) {
             errorForAction.addSuppressed(new ErrorId());
             if (error != errorForAction) {
                 // Make sure the original exception has the error ID, not just the copy here.

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java
@@ -37,6 +37,8 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.output.NullOutputStream;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
@@ -53,15 +55,19 @@ import org.kohsuke.accmod.restrictions.Beta;
  */
 public class ErrorAction implements PersistentAction {
 
+    private static final Logger LOGGER = Logger.getLogger(ErrorAction.class.getName());
+
     private final @NonNull Throwable error;
 
     public ErrorAction(@NonNull Throwable error) {
         if (isUnserializableException(error, new HashSet<>())) {
+            LOGGER.log(Level.FINE, "sanitizing unserializable error", error);
             error = new ProxyException(error);
         } else if (error != null) {
             try {
                 Jenkins.XSTREAM2.toXMLUTF8(error, new NullOutputStream());
             } catch (Exception x) {
+                LOGGER.log(Level.FINE, "unable to serialize to XML", x);
                 // Typically SecurityException from ClassFilter.
                 error = new ProxyException(error);
             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/actions/ErrorActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/actions/ErrorActionTest.java
@@ -349,15 +349,4 @@ public class ErrorActionTest {
         assertNotNull(new ErrorAction(unserializable));
         assertNotNull(new ErrorAction(cyclic));
     }
-
-    @Test public void findOriginOfRethrownUnserializableException() throws Throwable {
-        rr.then(r -> {
-            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-            p.setDefinition(new CpsFlowDefinition(
-                "stage('test') { withEnv([]) {  throw new " + X.class.getCanonicalName() + "() } }", false /* for "new org.jenkinsci.plugins.workflow.actions.ErrorActionTest$X" */));
-            WorkflowRun b = r.buildAndAssertStatus(Result.FAILURE, p);
-            FlowNode originNode = ErrorAction.findOrigin(b.getExecution().getCauseOfFailure(), b.getExecution());
-            assertThat(((StepNode) originNode).getDescriptor().getFunctionName(), equalTo("withEnv"));
-        });
-    }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/actions/ErrorActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/actions/ErrorActionTest.java
@@ -69,8 +69,6 @@ import org.jvnet.hudson.test.InboundAgentRule;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.jenkinsci.plugins.workflow.graph.StepNode;
-import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Tests for {@link ErrorAction}


### PR DESCRIPTION
A test case that passes on Java 11 but fails on 17; fix inspired by #327.

```
…
FINE	o.j.p.w.actions.ErrorAction#<init>: unable to serialize to XML
java.lang.reflect.InaccessibleObjectException: Unable to make field private static final long java.nio.channels.ClosedChannelException.serialVersionUID accessible: module java.base does not "opens java.nio.channels" to unnamed module @7c9d8e2
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
	at com.thoughtworks.xstream.converters.reflection.FieldDictionary.buildDictionaryEntryForClass(FieldDictionary.java:176)
	at com.thoughtworks.xstream.converters.reflection.FieldDictionary.buildMap(FieldDictionary.java:142)
	at com.thoughtworks.xstream.converters.reflection.FieldDictionary.fieldsFor(FieldDictionary.java:80)
	at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:167)
	at hudson.util.RobustReflectionConverter.doMarshal(RobustReflectionConverter.java:206)
…
Caused: java.lang.RuntimeException: Failed to serialize java.lang.Throwable#cause for class hudson.remoting.RequestAbortedException
	at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:274)
	at hudson.util.RobustReflectionConverter$2.visit(RobustReflectionConverter.java:241)
	at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:174)
…
[test0 #1] ERROR: Original failure:
[test0 #1] java.nio.channels.ClosedChannelException
[test0 #1] Also:   hudson.remoting.Channel$CallSiteStackTrace: Remote call to JNLP4-connect connection from localhost/127.0.0.1:55506
[test0 #1] 		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1787)
[test0 #1] 		at hudson.remoting.Request.call(Request.java:199)
[test0 #1] 		at hudson.remoting.Channel.call(Channel.java:1002)
[test0 #1] 		at hudson.FilePath.act(FilePath.java:1230)
[test0 #1] 		at hudson.FilePath.act(FilePath.java:1219)
[test0 #1] 		at org.jenkinsci.plugins.workflow.actions.ErrorActionTest$FailingStep.lambda$start$0(ErrorActionTest.java:316)
[test0 #1] 		at org.jenkinsci.plugins.workflow.steps.StepExecutions$SynchronousBodyVoid.lambda$asReturn$0(StepExecutions.java:45)
[test0 #1] 		at org.jenkinsci.plugins.workflow.steps.StepExecutions$SynchronousNonBlockingImpl.run(StepExecutions.java:99)
[test0 #1] 		at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
[test0 #1] 		at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
[test0 #1] 		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[test0 #1] Caused: hudson.remoting.RequestAbortedException
[test0 #1] 	at hudson.remoting.Request.abort(Request.java:346)
[test0 #1] 	at hudson.remoting.Channel.terminate(Channel.java:1083)
[test0 #1] 	at org.jenkinsci.remoting.protocol.impl.ChannelApplicationLayer.onReadClosed(ChannelApplicationLayer.java:241)
[test0 #1] 	at org.jenkinsci.remoting.protocol.ApplicationLayer.onRecvClosed(ApplicationLayer.java:221)
[test0 #1] 	at org.jenkinsci.remoting.protocol.ProtocolStack$Ptr.onRecvClosed(ProtocolStack.java:825)
[test0 #1] 	at org.jenkinsci.remoting.protocol.FilterLayer.onRecvClosed(FilterLayer.java:289)
[test0 #1] 	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.onRecvClosed(SSLEngineFilterLayer.java:168)
[test0 #1] 	at org.jenkinsci.remoting.protocol.ProtocolStack$Ptr.onRecvClosed(ProtocolStack.java:825)
[test0 #1] 	at org.jenkinsci.remoting.protocol.NetworkLayer.onRecvClosed(NetworkLayer.java:155)
[test0 #1] 	at org.jenkinsci.remoting.protocol.impl.NIONetworkLayer.ready(NIONetworkLayer.java:143)
[test0 #1] 	at org.jenkinsci.remoting.protocol.IOHub$OnReady.run(IOHub.java:789)
[test0 #1] 	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
[test0 #1] 	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
[test0 #1] 	at jenkins.util.ErrorLoggingExecutorService.lambda$wrap$0(ErrorLoggingExecutorService.java:51)
[test0 #1] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[test0 #1] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[test0 #1] 	at java.base/java.lang.Thread.run(Thread.java:840)
[test0 #1] Terminating callsFindOrigin (id: 3)
[test0 #1] [Pipeline] End of Pipeline
[test0 #1] java.lang.NullPointerException: Cannot invoke "org.jenkinsci.plugins.workflow.graph.FlowNode.getDisplayFunctionName()" because the return value of "org.jenkinsci.plugins.workflow.actions.ErrorAction.findOrigin(java.lang.Throwable, org.jenkinsci.plugins.workflow.flow.FlowExecution)" is null
[test0 #1] 	at org.jenkinsci.plugins.workflow.actions.ErrorActionTest$WrapperStep$Callback.onFailure(ErrorActionTest.java:293)
[test0 #1] Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: 1d275cd9-e796-406e-9d7d-50050a41013b
[test0 #1] Caused: java.lang.AssertionError
[test0 #1] 	at org.jenkinsci.plugins.workflow.actions.ErrorActionTest$WrapperStep$Callback.onFailure(ErrorActionTest.java:295)
…
```
