### PR TITLE
Small change to pipeline durability description

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/GlobalDefaultFlowDurabilityLevel.java
@@ -82,7 +82,7 @@ public class GlobalDefaultFlowDurabilityLevel extends AbstractDescribableImpl<Gl
         public ListBoxModel doFillDurabilityHintItems() {
             ListBoxModel options = new ListBoxModel();
 
-            options.add("None: use pipeline default (" + GlobalDefaultFlowDurabilityLevel.SUGGESTED_DURABILITY_HINT.name() + ")", "null");
+            options.add("None: use pipeline default (" + GlobalDefaultFlowDurabilityLevel.SUGGESTED_DURABILITY_HINT.getDescription()+ ")", "null");
 
             List<ListBoxModel.Option> mappedOptions = Arrays.stream(FlowDurabilityHint.values())
                     .map(hint -> new ListBoxModel.Option(hint.getDescription(), hint.name()))

--- a/src/main/resources/org/jenkinsci/plugins/workflow/flow/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/flow/Messages.properties
@@ -1,6 +1,6 @@
 FlowDurabilityHint.PERFORMANCE_OPTIMIZED.description=Performance-optimized: much faster (requires clean shutdown to save running pipelines)
 FlowDurabilityHint.PERFORMANCE_OPTIMIZED.tooltip=Avoids writing data with every step, avoids atomic writes of data.  Pipelines can resume if Jenkins shuts down cleanly, but running pipelines lose step information and cannot resume if Jenkins unexpectedly fails.
 FlowDurabilityHint.SURVIVABLE_NONATOMIC.description=Less durability, a bit faster (specialty use only)
-FlowDurabilityHint.SURVIVABLE_NONATOMIC.tooltip=Writes data with every step but avoids atomic writes. On some filesytems this is faster than maximum durability mode, but running pipeline data may be lost if disk writes are interrupted or fail.
-FlowDurabilityHint.MAX_SURVIVABILITY.description=Maximum durability but slowest (previously the only option)
+FlowDurabilityHint.SURVIVABLE_NONATOMIC.tooltip=Writes data with every step but avoids atomic writes. On some file systems this is faster than maximum durability mode, but running pipeline data may be lost if disk writes are interrupted or fail.
+FlowDurabilityHint.MAX_SURVIVABILITY.description=Maximum survivability/durability but slowest
 FlowDurabilityHint.MAX_SURVIVABILITY.tooltip=Writes data with every step, using atomic writes for integrity.  Provides maximum ability to retain running pipeline data and resume in the event of a Jenkins failure.


### PR DESCRIPTION
I have changed the wording on the durability settings to make sure users know that the settings for 'max survivability' and 'max durability' are actually the same thing. Previously to this change, the monitor displays the name of the enum instead of the description for it, making some users think there are 4 different options instead of 3.

I removed the (previously the only option) bit as could'nt see any more info on that in the documentation [here](https://www.jenkins.io/doc/book/pipeline/scaling-pipeline/#what-are-the-durability-settings) and wanted to just trim and make clearer.

Before:
![image](https://github.com/user-attachments/assets/c944e60a-156a-49db-8088-c1d6981cd52f)

After:
![image](https://github.com/user-attachments/assets/f15a3cce-3be7-4182-97b3-7239f30ab0d6)

This change is only description changes on the UI, so nothing to test other than manual tests to see the different wording. I also have a draft docs PR [here](https://github.com/jenkins-infra/jenkins.io/pull/7410) to sync the wording from this PR.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
