### PR TITLE
Add test for memory leak through `StepExecutionIterator` when build is stuck loading `programPromise`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ tags
 
 # mvn versions:set
 pom.xml.versionsBackup
+
+# MemoryAssert tests
+*.hprof


### PR DESCRIPTION
Comparable to https://github.com/jenkinsci/workflow-api-plugin/pull/347. 

I ran into another similar memory leak, but unlike in the previous case where the problematic build was stuck in an infinite loop in its `CpsVmExecutorService`, in this case the problematic build's `programPromise` was stuck and never finished loading pickles because a `FilePathPickle` was looping forever.

This PR just adds a test to show that the fix in the previous PR handles memory leaks in both cases.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
