### PR TITLE
Removing `FlowExecution.notifyShutdown`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecution.java
@@ -318,14 +318,6 @@ public abstract class FlowExecution implements FlowActionStorage, GraphLookupVie
     }
 
     /**
-     * @deprecated No longer used.
-     */
-    @Deprecated
-    protected void notifyShutdown() {
-        // Default is no-op
-    }
-
-    /**
      * Called after a restart and any attempts at {@link StepExecution#onResume} have completed.
      * This is a signal that it is safe to resume program execution.
      * By default, does nothing.

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionList.java
@@ -279,19 +279,9 @@ public class FlowExecutionList implements Iterable<FlowExecution> {
     }
 
     @Restricted(DoNotUse.class)
-    @SuppressWarnings("deprecation")
     @Terminator(requires = EXECUTIONS_SUSPENDED, attains = LIST_SAVED)
     public static void saveAll() throws InterruptedException {
         LOGGER.fine("ensuring all executions are saved");
-
-        for (FlowExecutionOwner owner : get().runningTasks.getView()) {
-            try {
-                owner.notifyShutdown();
-            } catch (Exception ex) {
-                LOGGER.log(Level.WARNING, "Error shutting down task", ex);
-            }
-        }
-
         SingleLaneExecutorService executor = get().executor;
         executor.shutdown();
         executor.awaitTermination(1, TimeUnit.MINUTES);

--- a/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionOwner.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionOwner.java
@@ -54,17 +54,6 @@ public abstract class FlowExecutionOwner implements Serializable {
     public abstract FlowExecution get() throws IOException;
 
     /**
-     * @deprecated No longer used.
-     */
-    @Deprecated
-    void notifyShutdown() {
-        FlowExecution exec = getOrNull();
-        if (exec != null) {
-            exec.notifyShutdown();
-        }
-    }
-
-    /**
      * Same as {@link #get} but avoids throwing an exception or blocking.
      * @return a valid flow execution, or null if not ready or invalid
      */


### PR DESCRIPTION
Has not been overridden since https://github.com/jenkinsci/workflow-cps-plugin/pull/766, and even then it did not do anything since https://github.com/jenkinsci/workflow-cps-plugin/pull/223#discussion_r183066039, so clean up.