### PR TITLE
Make `GCFlushedOutputStream` work as intended by switching to `Cleaner`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/log/GCFlushedOutputStream.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/GCFlushedOutputStream.java
@@ -28,18 +28,17 @@ import java.io.BufferedOutputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.lang.ref.PhantomReference;
-import java.lang.ref.ReferenceQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.remoting.ChannelClosedException;
+import hudson.remoting.DaemonThreadFactory;
+import hudson.remoting.NamingThreadFactory;
 import java.io.EOFException;
+import java.lang.ref.Cleaner;
 import java.nio.channels.ClosedChannelException;
 import java.util.stream.Stream;
-import jenkins.util.Timer;
 
 /**
  * A stream which will be flushed before garbage collection.
@@ -48,10 +47,12 @@ import jenkins.util.Timer;
 final class GCFlushedOutputStream extends FilterOutputStream {
     
     private static final Logger LOGGER = Logger.getLogger(GCFlushedOutputStream.class.getName());
+    private static final Cleaner CLEANER = Cleaner.create(
+            new NamingThreadFactory(new DaemonThreadFactory(), GCFlushedOutputStream.class.getName() + ".CLEANER"));
 
     GCFlushedOutputStream(OutputStream out) {
         super(out);
-        FlushRef.register(this, out);
+        CLEANER.register(this, new CleanerTask(out));
     }
 
     @Override public void write(@NonNull byte[] b, int off, int len) throws IOException {
@@ -80,40 +81,23 @@ final class GCFlushedOutputStream extends FilterOutputStream {
     /**
      * Flushes streams prior to garbage collection.
      * ({@link BufferedOutputStream} does not do this automatically.)
-     * TODO Java 9+ could use java.util.Cleaner
      */
-    private static final class FlushRef extends PhantomReference<GCFlushedOutputStream> {
-
-        private static final ReferenceQueue<GCFlushedOutputStream> rq = new ReferenceQueue<>();
-
-        static {
-            Timer.get().scheduleWithFixedDelay(() -> {
-                while (true) {
-                    FlushRef ref = (FlushRef) rq.poll();
-                    if (ref == null) {
-                        break;
-                    }
-                    LOGGER.log(Level.FINE, "flushing {0}", ref.out);
-                    try {
-                        ref.out.flush();
-                    } catch (IOException x) {
-                        LOGGER.log(isClosedChannelException(x) ? Level.FINE : Level.WARNING, null, x);
-                    }
-                }
-            }, 0, 10, TimeUnit.SECONDS);
-        }
-
-        static void register(GCFlushedOutputStream fos, OutputStream out) {
-            new FlushRef(fos, out, rq).enqueue();
-        }
-
+    private static final class CleanerTask implements Runnable {
         private final OutputStream out;
 
-        private FlushRef(GCFlushedOutputStream fos, OutputStream out, ReferenceQueue<GCFlushedOutputStream> rq) {
-            super(fos, rq);
+        public CleanerTask(OutputStream out) {
             this.out = out;
         }
 
+        @Override
+        public void run() {
+            LOGGER.log(Level.FINE, "flushing {0}", out);
+            try {
+                out.flush();
+            } catch (IOException x) {
+                LOGGER.log(isClosedChannelException(x) ? Level.FINE : Level.WARNING, null, x);
+            }
+        }
     }
 
 }


### PR DESCRIPTION
See https://github.com/jenkinsci/workflow-api-plugin/pull/83#discussion_r2018964003.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
