### PR TITLE
Replace `docker-fixtures` with `testcontainers`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,9 +123,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.test</groupId>
-            <artifactId>docker-fixtures</artifactId>
-            <version>200.v22a_e8766731c</version>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.21.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/resources/org/jenkinsci/plugins/workflow/ArtifactManagerTest/Dockerfile
+++ b/src/test/resources/org/jenkinsci/plugins/workflow/ArtifactManagerTest/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:noble
+
+# install requirements
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+        openjdk-17-jdk-headless \
+        openssh-server \
+        locales
+
+RUN mkdir -p /var/run/sshd
+
+# create a test user
+RUN useradd test -d /home/test && \
+    mkdir -p /home/test/.ssh && \
+    chown -R test:test /home/test && \
+    echo "test:test" | chpasswd
+
+# https://stackoverflow.com/a/38553499/12916
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8
+
+# run SSHD in the foreground with error messages to stderr
+ENTRYPOINT ["/usr/sbin/sshd", "-D", "-e"]


### PR DESCRIPTION
Replace `docker-fixtures` with `testcontainers`  (see https://github.com/jenkinsci/docker-fixtures/pull/122#issuecomment-3046351724)

This change removes already deprecated API methods from the test jar.

### Testing done

`mvn clean verfiy`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
