### PR TITLE
Remove 'Up' link

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/graph/FlowNode/sidepanel.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/graph/FlowNode/sidepanel.jelly
@@ -26,7 +26,6 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
   <l:side-panel>
     <l:tasks>
-      <l:task icon="icon-up icon-md" href="${rootURL}/${it.execution.owner.url}" title="${%Up}" contextMenu="false"/>
       <l:task icon="icon-search icon-md" href="${rootURL}/${it.url}" title="${%Status}" contextMenu="false"/>
       <st:include page="actions.jelly"/>
     </l:tasks>


### PR DESCRIPTION
Removes the 'Up' link from the side panel.

_Don't include hierarchical navigation in your sidebar, such as "Back to Dashboard" or "Up"_ - hierarchal navigation is discouraged in the [Design Library](https://weekly.ci.jenkins.io/design-library/layouts/).

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
