### PR TITLE
Avoid including unrelated content in step log after parse errors

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java
@@ -292,6 +292,7 @@ public final class FileLogStorage implements LogStorage {
                     // Note that NumberFormatException is nonfatal in the case of the overall build log:
                     // the whole-build HTML output always includes exactly what is in the main log file,
                     // at worst with some missing or inaccurate startStep/endStep annotations.
+                    pos = -1;
                     continue;
                 }
                 if (pos == -1) {
@@ -317,7 +318,10 @@ public final class FileLogStorage implements LogStorage {
                     raf.readFully(data);
                     buf.write(data);
                     pos = -1;
-                } // else some sort of mismatch
+                } else {
+                    // Some sort of mismatch. Do not emit this section.
+                    pos = -1;
+                }
             }
             if (pos != -1 && /* otherwise race condition? */ end > pos) {
                 // In case the build is ongoing and we are still actively writing content for this step,


### PR DESCRIPTION
While working on another patch, I noticed this subtle bug in the error handling of the per-step log reading. Let me know if you want me to create a Jira ticket first.

Previously, when not resetting the position on Long parse error or non-positive index change, the position of the next transition was mistaken for the end of the current section and the entire content since the last transition was emitted.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

The added tests are failing without this patch: The logs of step 1 contained the "between1\n" line -> "1\nbetween1\n". The atEnd tests would contain the "after" part.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
