### PR TITLE
Allow soft references in FlowExecutionListTest leak assertions

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/flow/FlowExecutionListTest.java
@@ -226,8 +226,9 @@ public class FlowExecutionListTest {
             notStuck.getLazyBuildMixIn().removeRun(notStuckBuild);
             notStuckBuild = null; // Clear out the local variable in this thread.
             Jenkins.get().getQueue().clearLeftItems(); // Otherwise we'd have to wait 5 minutes for the cache to be cleared.
-            // Make sure that the reference can be GC'd.
-            MemoryAssert.assertGC(notStuckBuildRef, false);
+            // Allow soft references from JVM and Groovy caches (Introspector, MetaClass)
+            // that are unrelated to the StepExecutionIterator code under test
+            MemoryAssert.assertGC(notStuckBuildRef, true);
             // Allow stuck #1 to complete so the test can be cleaned up promptly.
             SynchronousBlockingStep.unblock("stuck");
             r.waitForCompletion(stuckBuild);
@@ -263,8 +264,9 @@ public class FlowExecutionListTest {
             notStuck.getLazyBuildMixIn().removeRun(notStuckBuild);
             notStuckBuild = null; // Clear out the local variable in this thread.
             Jenkins.get().getQueue().clearLeftItems(); // Otherwise we'd have to wait 5 minutes for the cache to be cleared.
-            // Make sure that the reference can be GC'd.
-            MemoryAssert.assertGC(notStuckBuildRef, false);
+            // Allow soft references from JVM and Groovy caches (Introspector, MetaClass)
+            // that are unrelated to the StepExecutionIterator code under test
+            MemoryAssert.assertGC(notStuckBuildRef, true);
             // Allow stuck #1 to complete so the test can be cleaned up promptly.
             r.waitForMessage("Still trying to load StuckPickle for", stuckBuild);
             ExtensionList.lookupSingleton(StuckPickle.Factory.class).resolved = new StuckPickle.Marker();


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
An upcoming fix to `MemoryAssert.assertGC` in jenkins-test-harness (https://github.com/jenkinsci/jenkins-test-harness/pull/1029)) will cause `assertGC(ref, false)` to properly detect soft references. Without this change, these two tests would start failing once that fix lands

The soft references detected are from `java.beans.Introspector` and Groovy `MetaClass` invocation caches which is standard JVM/Groovy caching unrelated to the `StepExecutionIterator` code under test. These tests still verify there are no strong reference leaks

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
